### PR TITLE
Fix parse/validate split inconsistency

### DIFF
--- a/abi/amdsp.go
+++ b/abi/amdsp.go
@@ -171,5 +171,5 @@ func (e SevFirmwareErr) Error() string {
 	if e.Status == GuestRequestInvalidLength {
 		return "too few extended guest request data pages"
 	}
-	return fmt.Sprintf("unexpected firmware status (see SEV API spec): %x", e.Status)
+	return fmt.Sprintf("unexpected firmware status (see SEV API spec): %x", uint64(e.Status))
 }

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -485,6 +485,9 @@ func VcekDER(vcek []byte, ask []byte, ark []byte, options *Options) (*x509.Certi
 // SnpReportSignature verifies the attestation report's signature based on the report's
 // SignatureAlgo.
 func SnpReportSignature(report []byte, vcek *x509.Certificate) error {
+	if err := abi.ValidateReportFormat(report); err != nil {
+		return fmt.Errorf("attestation report format error: %v", err)
+	}
 	der, err := abi.ReportToSignatureDER(report)
 	if err != nil {
 		return fmt.Errorf("could not interpret report signature: %v", err)


### PR DESCRIPTION
The abi module leaves report version checking for "validation" but still
checks the policy format unnecessarily in a parsing function.

This commit separates validation more concretely and adds it as a step
to the verify module's main function for checking reports.

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>