### PR TITLE
Add caveated support for GetDerivedKey

### DIFF
--- a/LIMITATIONS.md
+++ b/LIMITATIONS.md
@@ -1,0 +1,69 @@
+# Security limitations
+
+This document's goal is to provide a short discussion on what security
+properties access to /dev/sev-guest has, specifically in a Cloud setting.
+
+## Initial assumptions
+
+For claims in this document, we assume that the VM firmware is vendored and
+signed by the vendor, or not signed at all. This will be the common use case.
+
+If a virtual machine monitor gives you access to provide your own launch image
+and signed IDBlock, then you have full control and responsibility over what that
+image does, and how careful it is to give workloads access to the SEV
+device. Since this library is for wrapping the Linux driver /dev/sev-guest which
+will be booted from a UEFI firmware, further discussion of other uses of SEV-SNP
+are out of scope.
+
+## Implications of a vendored firmware
+
+Your Cloud service provider (CSP) may launch SEV-SNP VMs with their own build of
+UEFI firmware. This build and its signature in IDBlock are probably widely
+deployed across the CSP's fleet.  Because the firmware and IDBlock are the same
+everywhere, the measurement in the attestation report will be the same
+everywhere. The IDBlock, if provided, may also be the same everywhere.
+
+The security of an attestation measurement or a derived key are proportional to
+the specificity of the initially measured image. If the initial image and its
+IDBlock is available to everyone and can run any workload, then keys bound to
+their measurement are known to everyone. An IDBlock signed by a different key
+will lead to different keys, but the IDBlock and ID Auth are also not secret
+in the SEV-SNP threat model. The measured image's behavior in granting
+authorization is what is important.
+
+At the moment, the basis for most VM firmware, Open Virtual Machine Firmware
+(OVMF), does not have the behavior to lock in such a specific measurement and
+authorization semantics in a way that is reflected in the SEV-SNP attestation
+report. Measured boot integrity is dynamic post-launch via the TPM 2.0
+specification, which for VMs is virtualized in software and not secret within
+the SEV-SNP threat model.
+
+Supposing we did have a boot stack that accounted for workload and its
+configuration in the SEV-SNP attestation report, software updates change the
+measurement and thus change the derived keys. In a self-updating VM, you'd need
+custom software to manage the implications of changing derived keys.
+
+## MSG_KEY_REQ, or GetDerivedKey
+
+Keys are derived from the launch information discussed above and the specific
+machine's SEV-SNP key called the Versioned Chip Endorsement Key (VCEK). When you
+do not have full control over the machine that derives the key, and your launch
+image isn't fully linked to the workload you trust to have access to the key,
+you should not set `UseVCEK` to true.
+
+With `UseVCEK` set to false, you must be using an image that supports a migration
+agent (MA). The MA will register a root key that migrates with the image, called
+the VMRK. The security of this VMRK is entirely up to the MA's logic. If the
+key is meant to persist across full shutdown and restart, then you have to solve
+a hard problem: sealing that key to persist in a way that only the authorized
+workload should later have access to. That is the same problem that exists for
+VCEK.
+
+If you're okay with keys that migrate but aren't otherwise recoverable, then
+VMRK key-based derivation should meet your needs. To many, that possibility of
+unrecoverable data loss is too risky to choose this option either.
+
+Because of the danger in both root key selections, we do not recommend using
+this command unless you have full ownership of and secure physical access to the
+machine that will run it, and trust all parties that run software on that
+machine.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ AMD SEV-SNP API formatted report and certificate table, or just `GetReport`,
 `GetReportAtVmpl`, `GetRawReport`, or `GetRawReportAtVmpl` to avoid fetching the
 certificate table.
 
+### `func GetDerivedKeyAcknowledgingItsLimitations(d Device, request *SnpDerivedKeyReq) ([]byte, error)`
+
+This function uses the `/dev/sev-guest` command for requesting a key derived
+from data that is measured at VM launch time, with the additional ability to
+continue to generate the same key as at earlier TCB and GuestSVN values.
+
+This function's name is selected to discourage its use in a Cloud setting. See
+[LIMITATIONS.md](LIMITATIONS.md).
+
 ### `func (d Device) Close() error`
 
 Closes the device.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-sev-guest/abi"
+	labi "github.com/google/go-sev-guest/client/linuxabi"
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
 	test "github.com/google/go-sev-guest/testing"
 	"google.golang.org/protobuf/encoding/prototext"
@@ -37,7 +38,15 @@ var tests []test.TestCase
 func initDevice() {
 	now := time.Date(2022, time.May, 3, 9, 0, 0, 0, time.UTC)
 	tests := test.TestCases()
-	newDevice, err := test.TcDevice(tests, now)
+	ones32 := make([]byte, 32)
+	for i := range ones32 {
+		ones32[i] = 1
+	}
+	keys := map[string][]byte{
+		test.DerivedKeyRequestToString(&labi.SnpDerivedKeyReqABI{}):                    make([]byte, 32),
+		test.DerivedKeyRequestToString(&labi.SnpDerivedKeyReqABI{GuestFieldSelect: 1}): ones32,
+	}
+	newDevice, err := test.TcDevice(tests, keys, now)
 	if err != nil { // Unexpected
 		panic(err)
 	}
@@ -140,5 +149,41 @@ func TestOpenGetExtendedReportClose(t *testing.T) {
 					ereport.GetCertificateChain().GetVcekCert(), d.Signer.Vcek.Raw)
 			}
 		}
+	}
+}
+
+func TestGetDerivedKey(t *testing.T) {
+	devMu.Do(initDevice)
+	d := device
+	if err := d.Open("/dev/sev-guest"); err != nil {
+		t.Error(err)
+	}
+	defer d.Close()
+	key1, err := GetDerivedKeyAcknowledgingItsLimitations(device, &SnpDerivedKeyReq{
+		UseVCEK: true,
+	})
+	if err != nil {
+		t.Fatal("Could not get key1: %v", err)
+	}
+	key2, err := GetDerivedKeyAcknowledgingItsLimitations(device, &SnpDerivedKeyReq{
+		UseVCEK: true,
+		GuestFieldSelect: GuestFieldSelect{
+			GuestPolicy: true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Could not get key2: %v", err)
+	}
+	key3, err := GetDerivedKeyAcknowledgingItsLimitations(device, &SnpDerivedKeyReq{
+		UseVCEK: true,
+	})
+	if err != nil {
+		t.Fatalf("Could not get key3: %v", err)
+	}
+	if bytes.Equal(key1, key2) {
+		t.Errorf("GetDerivedKey...(nothing) = %v = GetDerivedKey...(guestPolicy) = %v", key1, key2)
+	}
+	if !bytes.Equal(key1, key3) {
+		t.Errorf("GetDerivedKey...(nothing) = %v and %v. Expected equality", key1, key3)
 	}
 }

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -152,7 +152,7 @@ func TestCases() []TestCase {
 }
 
 // TcDevice returns a mock device populated from test cases' inputs and expected outputs.
-func TcDevice(tcs []TestCase, now time.Time) (*Device, error) {
+func TcDevice(tcs []TestCase, keys map[string][]byte, now time.Time) (*Device, error) {
 	certs, signer, err := makeTestCerts(now)
 	if err != nil {
 		return nil, fmt.Errorf("test failure creating certificates: %v", err)
@@ -169,5 +169,6 @@ func TcDevice(tcs []TestCase, now time.Time) (*Device, error) {
 		UserDataRsp: responses,
 		Certs:       certs,
 		Signer:      signer,
+		Keys:        keys,
 	}, nil
 }

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -135,7 +135,7 @@ func TestVerifyVcekCert(t *testing.T) {
 func TestSnpReportSignature(t *testing.T) {
 	tests := test.TestCases()
 	now := time.Date(2022, time.May, 3, 9, 0, 0, 0, time.UTC)
-	d, err := test.TcDevice(tests, now)
+	d, err := test.TcDevice(tests, nil, now)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -387,7 +387,7 @@ func TestCRLRootValidity(t *testing.T) {
 
 func TestOpenGetExtendedReportVerifyClose(t *testing.T) {
 	tests := test.TestCases()
-	d, err := test.TcDevice(tests, time.Now())
+	d, err := test.TcDevice(tests, nil, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This adds the SNP_GET_DERIVED_KEY command for ioctl coverage, but with extra caution tape around it to ensure the user has considered what environment they're using the command in.

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>