### PR TITLE
Fix linter errors

### DIFF
--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -103,7 +103,7 @@ func TestReportMbz(t *testing.T) {
 		// Everything but the signature hase
 		raw, err := ReportToAbiBytes(reportProto)
 		if err != nil {
-			t.Fatalf("%s: test failure: ReportToAbiBytes(%v) errored unexpectely: %v", tc.name, reportProto, err)
+			t.Fatalf("%s: test failure: ReportToAbiBytes(%v) errored unexpectedly: %v", tc.name, reportProto, err)
 		}
 		changeValue := byte(0xcc)
 		if tc.changeValue != 0 {
@@ -132,7 +132,7 @@ func TestSnpPolicySection(t *testing.T) {
 
 		got, err := ParseSnpPolicy(SnpPolicyToBytes(policy))
 		if err != nil {
-			t.Errorf("ParseSnpPolicy(SnpPolicyToBytes(%v)) errored unexpectely: %v", policy, err)
+			t.Errorf("ParseSnpPolicy(SnpPolicyToBytes(%v)) errored unexpectedly: %v", policy, err)
 		}
 		if got != policy {
 			t.Errorf("ParseSnpPolicy(SnpPolicyToBytes(%v)) = %v, want %v", policy, got, policy)

--- a/abi/amdsp.go
+++ b/abi/amdsp.go
@@ -23,81 +23,81 @@ type SevFirmwareStatus int
 // Unexported errors are not expected to leave the kernel.
 const (
 	// Success denotes successful completion of a firmware command.
-	Success SevFirmwareStatus = iota
+	Success SevFirmwareStatus = 0
 	// InvalidPlatformState is the code for the platform to be in the wrong state for a given command.
-	InvalidPlatformState
+	InvalidPlatformState = 1
 	// InvalidGuestState is the code for the guest to be in the wrong state for a given command.
-	InvalidGuestState
+	InvalidGuestState = 2
 	// Platform owner error unexpected by guest command.
-	invalidConfig
+	// invalidConfig = 3
 	// InvalidLength is the code for a provided buffer size is too small to complete the command.
-	InvalidLength
+	InvalidLength = 4
 	// Platform owner error unexpected by guest command.
-	alreadyOwned
+	// alreadyOwned = 5
 	// Platform owner error unexpected by guest command.
-	invalidCertificate
+	// invalidCertificate = 6
 	// PolicyFailure is the code for when the guest policy disallows the command.
-	PolicyFailure
+	PolicyFailure = 7
 	// Inactive is the code for when a command is sent for a guest, but the guest is inactive.
-	Inactive
+	Inactive = 8
 	// InvalidAddress is the code for when a provided address is invalid.
-	InvalidAddress
+	InvalidAddress = 9
 	// User error expected at launch, unexpected here.
-	badSignature
+	// badSignature = 10
 	// User error expected at launch, unexpected here.
-	badMeasurement
+	// badMeasurement = 11
 	// Kernel error, unexpected.
-	asidOwned
+	// asidOwned = 12
 	// Kernel error, unexpected.
-	invalidAsid
+	// invalidAsid = 13
 	// Kernel error, unexpected.
-	wbinvdRequired
+	// wbinvdRequired = 14
 	// Kernel error, unexpected.
-	dfFlushRequired
+	// dfFlushRequired = 15
 	// Kernel error, unexpected.
-	invalidGuest
+	// invalidGuest = 16
 	// InvalidCommand is the code for when the command code is invalid.
-	InvalidCommand
+	InvalidCommand = 17
 	// Kernel error, unexpected.
-	active
+	// active = 18
 	// HwErrorPlatform is the code for when the hardware failed but it's okay to update its buffers.
-	HwErrorPlatform
+	HwErrorPlatform = 19
 	// HwErrorUnsafe is the code for when the hardware failed and it's unsafe to update its buffers.
-	HwErrorUnsafe
+	HwErrorUnsafe = 20
 	// Unsupported is for an unsupported feature.
-	Unsupported
+	Unsupported = 21
 	// InvalidParam is the code for an invalid parameter in a command.
-	InvalidParam
+	InvalidParam = 22
 	// ResourceLimit is the code for when the firmware has reached a resource limit and can't complete the command.
-	ResourceLimit
+	ResourceLimit = 23
 	// SecureDataInvalid is the code for when a hardware integrity check has failed.
-	SecureDataInvalid
+	SecureDataInvalid = 24
 	// InvalidPageSize indicates an RMP error with the recorded page size.
-	InvalidPageSize
+	InvalidPageSize = 25
 	// InvalidPageState indicates an RMP error with the recorded page state.
-	InvalidPageState
+	InvalidPageState = 26
 	// InvalidMdataEntry indicates an RMP error with the recorded metadata.
-	InvalidMdataEntry
+	InvalidMdataEntry = 27
 	// InvalidPageOwner indicates an RMP error with ASID mismatch between accessors.
-	InvalidPageOwner
+	InvalidPageOwner = 28
 	// AeadOflow indicates that firmware memory capacity is reached in the AEAD cryptographic algorithm.
-	AeadOflow
+	AeadOflow = 29
 	// Skip code 0x1E since AeaedOflow is 0x1D and rbModeExited is 0x1F.
-	reserved1e
+	// reserved1e = 30
 	// Kernel error, unexpected.
-	rbModeExited
+	// rbModeExited = 31
 	// Kernel error, unexpected.
-	rmpInitRequired
+	// rmpInitRequired = 32
 	// Platform management error, unexpected.
-	badSvn
+	// badSvn = 33
 	// Platform management error, unexpected.
-	badVersion
+	// badVersion = 34
 	// Platform management error, unexpected.
-	shutdownRequired
+	// shutdownRequired = 35
 	// Platform management error, unexpected.
-	updateFailed
+	// updateFailed = 36
 	// Platform management error, unexpected.
-	restoreRequired
+	// restoreRequired = 37
 )
 
 // GuestRequestInvalidLength is set by the ccp driver and not the AMD-SP when an guest extended

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -102,7 +102,7 @@ func TestOpenGetRawExtendedReportClose(t *testing.T) {
 			}
 			der, err := abi.ReportToSignatureDER(raw)
 			if err != nil {
-				t.Errorf("ReportToSignatureDER(%v) errored unexpectely: %v", raw, err)
+				t.Errorf("ReportToSignatureDER(%v) errored unexpectedly: %v", raw, err)
 			}
 			if err := d.Signer.Vcek.CheckSignature(x509.ECDSAWithSHA384, got, der); err != nil {
 				t.Errorf("signature with test keys did not verify: %v", err)

--- a/testing/fake_certs.go
+++ b/testing/fake_certs.go
@@ -76,7 +76,7 @@ func (s *AmdSigner) Sign(toSign []byte) (*big.Int, *big.Int, error) {
 	return R, S, nil
 }
 
-// CertOverride encapsulates certificate aspects that can be overriden when creating a certificate
+// CertOverride encapsulates certificate aspects that can be overridden when creating a certificate
 // chain.
 type CertOverride struct {
 	// If 0, interpreted as Version, otherwise the ARK cert version number.

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -25,8 +25,9 @@ import (
 	"encoding/hex"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
+	"os"
 	"sync"
 	"time"
 
@@ -138,7 +139,7 @@ func (r *AMDRootCerts) FromKDSCertBytes(data []byte) error {
 // FromKDSCert populates r's AskX509 and ArkX509 certificates from the certificate format AMD's Key
 // Distribution Service (KDS) uses, e.g., https://kdsintf.amd.com/vcek/v1/Milan/cert_chain
 func (r *AMDRootCerts) FromKDSCert(path string) error {
-	certBytes, err := ioutil.ReadFile(path)
+	certBytes, err := os.ReadFile(path)
 	if err != nil {
 		return err
 	}
@@ -514,7 +515,7 @@ func SnpProtoReportSignature(report *spb.Report, vcek *x509.Certificate) error {
 
 // Options represents verification options for an SEV-SNP attestation report.
 type Options struct {
-	// CheckRevocations set to true if the verifier should retreive the CRL from the network and check
+	// CheckRevocations set to true if the verifier should retrieve the CRL from the network and check
 	// if the VCEK or ASK have been revoked according to the ARK.
 	CheckRevocations bool
 	// Getter takes a URL and returns the body of its contents. By default uses http.Get and returns
@@ -563,7 +564,7 @@ func (n *SimpleHTTPSGetter) Get(url string) ([]byte, error) {
 		return nil, errors.New("failed to retrieve CRL")
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Typos, unused constants, and ioutil is deprecated.

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>