### PR TITLE
Change variables to be more consistent with AMD's docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This type contains three fields:
     certificate revocation list (CRL) and check for revocations.
 *   `Getter HTTPSGetter`: must be non-`nil` if `CheckRevocations` is true.
 *   `TrustedRoots map[string][]*AMDRootCerts`: if `nil`, uses the library's embedded certificates.
-     Maps a platform name to all allowed root certifications for that platform (e.g., Milan).
+     Maps a product name to all allowed root certifications for that product (e.g., Milan).
 
 The `HTTPSGetter` interface consists of a single method `Get(url string)
 ([]byte, error)` that should return the body of the HTTPS response.
@@ -101,7 +101,7 @@ The `HTTPSGetter` interface consists of a single method `Get(url string)
 
 This type has 6 fields, the first 3 of which are mandatory:
 
-*   `Platform string`: the name of the platform this bundle is for (e.g., `"Milan"`).
+*   `Product string`: the name of the product this bundle is for (e.g., `"Milan"`).
 *   `AskX509 *x509.Certificate`: an X.509 representation of the AMD SEV Signer intermediate key (ASK)'s certificate.
 *   `ArkX509 *x509.Certificate`: an X.509 representation of the AMD SEV Root key (ARK)'s certificate.
 *   `AskSev *abi.AskCert`: if non-`nil`, will cross-check with

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This function creates a file descriptor to the `/dev/sev-guest` device and
 returns an object that has methods encapsulating commands to the device. When
 done, remember to `Close()` the device.
 
-### `func GetExtendedReport(d Device, userData [64]byte) (*pb.Attestation, error)`
+### `func GetExtendedReport(d Device, reportData [64]byte) (*pb.Attestation, error)`
 
 This function takes an object implementing the `Device` interface (e.g., a
 `LinuxDevice`) and returns the protocol buffer representation of the attestation
@@ -134,7 +134,7 @@ fields of an attestation report.
 
 The fields that either can be skipped or must match the given value exactly are:
 
-*   `UserData` for the `REPORT_DATA` field
+*   `ReportData` for the `REPORT_DATA` field
 *   `HostData` for the `HOST_DATA` field
 *   `ImageID` for the `IMAGE_ID` field
 *   `FamilyID` for the `FAMILY_ID` field

--- a/client/linuxabi/linux_abi.go
+++ b/client/linuxabi/linux_abi.go
@@ -108,8 +108,8 @@ func (err SevEsErr) Error() string {
 // SnpReportReqABI is Linux's sev-guest ioctl abi for sending a GET_REPORT request. See
 // include/uapi/linux/sev-guest.h
 type SnpReportReqABI struct {
-	// UserData to be included in the report
-	UserData [64]uint8
+	// ReportData to be included in the report
+	ReportData [64]uint8
 
 	// Vmpl is the SEV-SNP VMPL level to be included in the report.
 	// The kernel must have access to the corresponding VMPCK.

--- a/kds/kds.go
+++ b/kds/kds.go
@@ -339,9 +339,9 @@ func VcekCertificateExtensions(cert *x509.Certificate) (*VcekExtensions, error) 
 	return extensions, nil
 }
 
-// ParsePlatformCertChain returns the DER-formatted certificates represented by the body
-// of the PlatformCertChain (cert_chain) endpoint, ASK and ARK in that order.
-func ParsePlatformCertChain(pems []byte) ([]byte, []byte, error) {
+// ParseProductCertChain returns the DER-formatted certificates represented by the body
+// of the ProductCertChain (cert_chain) endpoint, ASK and ARK in that order.
+func ParseProductCertChain(pems []byte) ([]byte, []byte, error) {
 	checkForm := func(name string, b *pem.Block) error {
 		if b == nil {
 			return fmt.Errorf("could not find %s PEM block", name)
@@ -365,23 +365,23 @@ func ParsePlatformCertChain(pems []byte) ([]byte, []byte, error) {
 	return askBlock.Bytes, arkBlock.Bytes, nil
 }
 
-// platformBaseURL returns the base URL for all certificate queries within a particular platform.
-func platformBaseURL(name string) string {
+// productBaseURL returns the base URL for all certificate queries within a particular product.
+func productBaseURL(name string) string {
 	return fmt.Sprintf("%s/vcek/v1/%s", kdsBaseURL, name)
 }
 
-// PlatformCertChainURL returns the AMD KDS URL for retrieving the ARK and ASK
-// certificates on the given platform in PEM format.
-func PlatformCertChainURL(platform string) string {
-	return fmt.Sprintf("%s/cert_chain", platformBaseURL(platform))
+// ProductCertChainURL returns the AMD KDS URL for retrieving the ARK and ASK
+// certificates on the given product in PEM format.
+func ProductCertChainURL(product string) string {
+	return fmt.Sprintf("%s/cert_chain", productBaseURL(product))
 }
 
-// VCEKCertURL returns the AMD KDS URL for retrieving the VCEK on a given platform
+// VCEKCertURL returns the AMD KDS URL for retrieving the VCEK on a given product
 // at a given TCB version. The hwid is the CHIP_ID field in an attestation report.
-func VCEKCertURL(platform string, hwid []byte, tcb TCBVersion) string {
+func VCEKCertURL(product string, hwid []byte, tcb TCBVersion) string {
 	parts := DecomposeTCBVersion(tcb)
 	return fmt.Sprintf("%s/%s?blSPL=%d&teeSPL=%d&snpSPL=%d&ucodeSPL=%d",
-		platformBaseURL(platform),
+		productBaseURL(product),
 		hex.EncodeToString(hwid),
 		parts.BlSpl,
 		parts.TeeSpl,

--- a/testing/mocks.go
+++ b/testing/mocks.go
@@ -32,11 +32,11 @@ type GetReportResponse struct {
 
 // Device represents a sev-guest driver implementation with pre-programmed responses to commands.
 type Device struct {
-	isOpen      bool
-	UserDataRsp map[string]interface{}
-	Keys        map[string][]byte
-	Certs       []byte
-	Signer      *AmdSigner
+	isOpen        bool
+	ReportDataRsp map[string]interface{}
+	Keys          map[string][]byte
+	Certs         []byte
+	Signer        *AmdSigner
 }
 
 // Open changes the mock device's state to open.
@@ -58,9 +58,9 @@ func (d *Device) Close() error {
 }
 
 func (d *Device) getReport(req *labi.SnpReportReqABI, rsp *labi.SnpReportRespABI, fwErr *uint64) (uintptr, error) {
-	mockRspI, ok := d.UserDataRsp[hex.EncodeToString(req.UserData[:])]
+	mockRspI, ok := d.ReportDataRsp[hex.EncodeToString(req.ReportData[:])]
 	if !ok {
-		return 0, fmt.Errorf("test error: no response for %v", req.UserData)
+		return 0, fmt.Errorf("test error: no response for %v", req.ReportData)
 	}
 	mockRsp, ok := mockRspI.(*GetReportResponse)
 	if !ok {

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -24,10 +24,10 @@ import (
 	labi "github.com/google/go-sev-guest/client/linuxabi"
 )
 
-// userZeros defines a UserData example that is all zeros
+// userZeros defines a ReportData example that is all zeros
 var userZeros [64]byte
 
-// userZeros1 defines a UserData example that is all zeros except the last byte is 1.
+// userZeros1 defines a ReportData example that is all zeros except the last byte is 1.
 var userZeros1 = [64]byte{
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0,
@@ -38,7 +38,7 @@ var userZeros1 = [64]byte{
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 1}
 
-// userZeros11 defines a UserData example that is all zeros except the last 2 bytes are both 1.
+// userZeros11 defines a ReportData example that is all zeros except the last 2 bytes are both 1.
 var userZeros11 = [64]byte{
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0,
@@ -91,7 +91,7 @@ var oneReport = `
 // We can't sign the report with AMD keys, and verification isn't the client's responsibility, so
 // we keep the signature zeros.
 // Similarly, we leave the randomly-generated fields zero.
-func TestRawReport(userData [64]byte) [labi.SnpReportRespReportSize]byte {
+func TestRawReport(reportData [64]byte) [labi.SnpReportRespReportSize]byte {
 	var r [labi.SnpReportRespReportSize]byte
 	// Set Version to 2
 	binary.LittleEndian.PutUint32(r[0x00:0x04], 2)
@@ -99,7 +99,7 @@ func TestRawReport(userData [64]byte) [labi.SnpReportRespReportSize]byte {
 	// Signature algorithm ECC P-384 with SHA-384 is encoded as 1.
 	binary.LittleEndian.PutUint32(r[0x34:0x38], 1)
 	// Place user data in its report location.
-	copy(r[0x50:0x90], userData[:])
+	copy(r[0x50:0x90], reportData[:])
 	return r
 }
 
@@ -178,9 +178,9 @@ func TcDevice(tcs []TestCase, opts *DeviceOptions) (*Device, error) {
 		}
 	}
 	return &Device{
-		UserDataRsp: responses,
-		Certs:       certs,
-		Signer:      signer,
-		Keys:        opts.Keys,
+		ReportDataRsp: responses,
+		Certs:         certs,
+		Signer:        signer,
+		Keys:          opts.Keys,
 	}, nil
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -34,8 +34,8 @@ import (
 type Options struct {
 	// GuestPolicy is the maximum of acceptable guest policies.
 	GuestPolicy abi.SnpPolicy
-	// UserData is the expected REPORT_DATA field. Must be nil or 64 bytes long. Not checked if nil.
-	UserData []byte
+	// ReportData is the expected REPORT_DATA field. Must be nil or 64 bytes long. Not checked if nil.
+	ReportData []byte
 	// HostData is the expected HOST_DATA field. Must be nil or 32 bytes long. Not checked if nil.
 	HostData []byte
 	// ImageID is the expected IMAGE_ID field. Must be nil or 16 bytes long. Not checked if nil.
@@ -139,7 +139,7 @@ func validateByteField(option, field string, size int, given, required []byte) e
 
 func validateVerbatimFields(report *spb.Report, options *Options) error {
 	return multierr.Combine(
-		validateByteField("UserData", "REPORT_DATA", abi.ReportDataSize, report.GetReportData(), options.UserData),
+		validateByteField("ReportData", "REPORT_DATA", abi.ReportDataSize, report.GetReportData(), options.ReportData),
 		validateByteField("HostData", "HOST_DATA", abi.HostDataSize, report.GetHostData(), options.HostData),
 		validateByteField("FamilyID", "FAMILY_ID", abi.FamilyIDSize, report.GetFamilyId(), options.FamilyID),
 		validateByteField("ImageID", "IMAGE_ID", abi.ImageIDSize, report.GetImageId(), options.ImageID),

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -265,7 +265,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 	}
 	tests := []testCase{
 		{
-			name: "just userData",
+			name: "just reportData",
 			attestation: func() *spb.Attestation {
 				report, err := sg.GetReport(device0, nonce0s1)
 				if err != nil {
@@ -278,13 +278,13 @@ func TestValidateSnpAttestation(t *testing.T) {
 						VcekCert: sign0.Vcek.Raw,
 					}}
 			}(),
-			opts: &Options{UserData: nonce0s1[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
+			opts: &Options{ReportData: nonce0s1[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
 		},
 		{
 			name:        "deep check",
 			attestation: attestation12345,
 			opts: &Options{
-				UserData:               nonce12345[:],
+				ReportData:             nonce12345[:],
 				GuestPolicy:            abi.SnpPolicy{Debug: true, SMT: true},
 				PlatformInfo:           &abi.SnpPlatformInfo{SMTEnabled: true},
 				Measurement:            measurement,
@@ -306,7 +306,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			name:        "Minimum TCB checked",
 			attestation: attestation12345,
 			opts: &Options{
-				UserData:     nonce12345[:],
+				ReportData:   nonce12345[:],
 				GuestPolicy:  abi.SnpPolicy{Debug: true, SMT: true},
 				PlatformInfo: &abi.SnpPlatformInfo{SMTEnabled: true},
 				MinimumTCB:   kds.TCBParts{UcodeSpl: 0xff, SnpSpl: 0x05, BlSpl: 0x02},
@@ -317,7 +317,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			name:        "Minimum build checked",
 			attestation: attestation12345,
 			opts: &Options{
-				UserData:     nonce12345[:],
+				ReportData:   nonce12345[:],
 				GuestPolicy:  abi.SnpPolicy{Debug: true, SMT: true},
 				PlatformInfo: &abi.SnpPlatformInfo{SMTEnabled: true},
 				MinimumBuild: 3,
@@ -328,7 +328,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			name:        "Minimum version checked",
 			attestation: attestation12345,
 			opts: &Options{
-				UserData:       nonce12345[:],
+				ReportData:     nonce12345[:],
 				GuestPolicy:    abi.SnpPolicy{Debug: true, SMT: true},
 				PlatformInfo:   &abi.SnpPlatformInfo{SMTEnabled: true},
 				MinimumVersion: 0xff00,
@@ -339,7 +339,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			name:        "Author key checked",
 			attestation: attestation54321,
 			opts: &Options{
-				UserData:         nonce54321[:],
+				ReportData:       nonce54321[:],
 				GuestPolicy:      abi.SnpPolicy{Debug: true, SMT: true},
 				PlatformInfo:     &abi.SnpPlatformInfo{SMTEnabled: true},
 				RequireAuthorKey: true,
@@ -352,7 +352,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			name:        "PlatformInfo checked",
 			attestation: attestation54321,
 			opts: &Options{
-				UserData:     nonce54321[:],
+				ReportData:   nonce54321[:],
 				GuestPolicy:  abi.SnpPolicy{Debug: true, SMT: true},
 				PlatformInfo: &abi.SnpPlatformInfo{},
 			},
@@ -362,7 +362,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			name:        "Requiring IDBlock requires trust",
 			attestation: attestation12345,
 			opts: &Options{
-				UserData:       nonce12345[:],
+				ReportData:     nonce12345[:],
 				GuestPolicy:    abi.SnpPolicy{Debug: true, SMT: true},
 				PlatformInfo:   &abi.SnpPlatformInfo{SMTEnabled: true},
 				RequireIDBlock: true,
@@ -375,7 +375,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			name:        "accepted provisional by build",
 			attestation: attestationb1455,
 			opts: &Options{
-				UserData:                  nonceb1455[:],
+				ReportData:                nonceb1455[:],
 				GuestPolicy:               abi.SnpPolicy{Debug: true},
 				PermitProvisionalFirmware: true,
 			},
@@ -383,14 +383,14 @@ func TestValidateSnpAttestation(t *testing.T) {
 		{
 			name:        "rejected provisional by build",
 			attestation: attestationb1455,
-			opts:        &Options{UserData: nonceb1455[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
+			opts:        &Options{ReportData: nonceb1455[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
 			wantErr:     "committed build number 1 does not match the current build number 2",
 		},
 		{
 			name:        "accepted provisional by tcb",
 			attestation: attestationcb1455,
 			opts: &Options{
-				UserData:                  noncecb1455[:],
+				ReportData:                noncecb1455[:],
 				GuestPolicy:               abi.SnpPolicy{Debug: true},
 				PermitProvisionalFirmware: true,
 			},
@@ -398,14 +398,14 @@ func TestValidateSnpAttestation(t *testing.T) {
 		{
 			name:        "rejected provisional by tcb",
 			attestation: attestationcb1455,
-			opts:        &Options{UserData: noncecb1455[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
+			opts:        &Options{ReportData: noncecb1455[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
 			wantErr:     "firmware's committed TCB 9270000000007f00 does not match the current TCB 9270000000007f1f",
 		},
 		{
 			name:        "accepted provisional by version",
 			attestation: attestation11355,
 			opts: &Options{
-				UserData:                  nonce11355[:],
+				ReportData:                nonce11355[:],
 				GuestPolicy:               abi.SnpPolicy{Debug: true},
 				PermitProvisionalFirmware: true,
 			},
@@ -413,7 +413,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 		{
 			name:        "rejected provisional by version",
 			attestation: attestation11355,
-			opts:        &Options{UserData: nonce11355[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
+			opts:        &Options{ReportData: nonce11355[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
 			wantErr:     "committed API version (1.49) does not match the current API version (1.51)",
 		},
 	}
@@ -427,7 +427,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 		switch i {
 		case 0:
 			name = "REPORT_DATA"
-			opts.UserData = make([]byte, abi.ReportDataSize)
+			opts.ReportData = make([]byte, abi.ReportDataSize)
 		case 1:
 			name = "HOST_DATA"
 			opts.HostData = make([]byte, abi.HostDataSize)

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -45,13 +45,13 @@ var milanBytes []byte
 //go:embed testdata/attestation.bin
 var attestationBytes []byte
 
-const platform = "Milan"
+const product = "Milan"
 
 var signMu sync.Once
 var signer *test.AmdSigner
 
 func initSigner() {
-	newSigner, err := test.DefaultCertChain(platform, time.Now())
+	newSigner, err := test.DefaultCertChain(product, time.Now())
 	if err != nil { // Unexpected
 		panic(err)
 	}
@@ -74,9 +74,9 @@ func TestEmbeddedCertsAppendixB3Expectations(t *testing.T) {
 func TestFakeCertsKDSExpectations(t *testing.T) {
 	signMu.Do(initSigner)
 	root := AMDRootCerts{
-		Platform: platform,
-		ArkX509:  signer.Ark,
-		AskX509:  signer.Ask,
+		Product: product,
+		ArkX509: signer.Ark,
+		AskX509: signer.Ask,
 		// No ArkSev or AskSev intentionally for test certs.
 	}
 	if err := root.ValidateArkX509(); err != nil {
@@ -92,7 +92,7 @@ func TestParseVcekCert(t *testing.T) {
 	if err != nil {
 		t.Errorf("could not parse valid VCEK certificate: %v", err)
 	}
-	if _, err := validateVcekCertificatePlatformNonspecific(cert); err != nil {
+	if _, err := validateVcekCertificateProductNonspecific(cert); err != nil {
 		t.Errorf("could not validate valid VCEK certificate: %v", err)
 	}
 }
@@ -112,7 +112,7 @@ func TestVerifyVcekCert(t *testing.T) {
 	if opts == nil {
 		t.Fatalf("root x509 certificates missing: %v", root)
 	}
-	// This time is within the 25 year lifespan of the Milan platform.
+	// This time is within the 25 year lifespan of the Milan product.
 	opts.CurrentTime = time.Date(2022, time.September, 24, 1, 0, 0, 0, time.UTC)
 	chains, err := vcek.Verify(*opts)
 	if err != nil {
@@ -292,9 +292,9 @@ func TestKdsMetadataLogic(t *testing.T) {
 		// won't get tested.
 		options := &Options{TrustedRoots: map[string][]*AMDRootCerts{
 			"Milan": {&AMDRootCerts{
-				Platform: "Milan",
-				ArkX509:  newSigner.Ark,
-				AskX509:  newSigner.Ask,
+				Product: "Milan",
+				ArkX509: newSigner.Ark,
+				AskX509: newSigner.Ask,
 			}},
 		}}
 		if tc.wantErr != "" {
@@ -356,9 +356,9 @@ func TestCRLRootValidity(t *testing.T) {
 		Number: big.NewInt(1),
 	}
 	root := &AMDRootCerts{
-		Platform: "Milan",
-		ArkX509:  signer.Ark,
-		AskX509:  signer.Ask,
+		Product: "Milan",
+		ArkX509: signer.Ark,
+		AskX509: signer.Ask,
 	}
 
 	// Now try signing a CRL with a different root that certifies Vcek with a different serial number.
@@ -378,9 +378,9 @@ func TestCRLRootValidity(t *testing.T) {
 
 	// Finally try checking a VCEK that's signed by a revoked ASK.
 	root2 := &AMDRootCerts{
-		Platform: "Milan",
-		ArkX509:  signer2.Ark,
-		AskX509:  signer2.Ask,
+		Product: "Milan",
+		ArkX509: signer2.Ark,
+		AskX509: signer2.Ask,
 	}
 	wantErr2 := "ASK was revoked at 2022-06-14 12:01:00 +0000 UTC"
 	if err := root2.VcekNotRevoked(g2, signer2.Vcek); err == nil || !strings.Contains(err.Error(), wantErr2) {
@@ -401,9 +401,9 @@ func TestOpenGetExtendedReportVerifyClose(t *testing.T) {
 	// Trust the test device's root certs.
 	options := &Options{TrustedRoots: map[string][]*AMDRootCerts{
 		"Milan": {&AMDRootCerts{
-			Platform: "Milan",
-			ArkX509:  d.Signer.Ark,
-			AskX509:  d.Signer.Ask,
+			Product: "Milan",
+			ArkX509: d.Signer.Ark,
+			AskX509: d.Signer.Ask,
 		}}}}
 	for _, tc := range tests {
 		ereport, err := sg.GetExtendedReport(d, tc.Input)


### PR DESCRIPTION
I used "platform" when I should have used "product", and "userdata" where I should have used "reportdata". Fix these inconsistencies.