### PR TITLE
Recognize retry error from VMM

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -109,6 +109,44 @@ const (
 	ExpectedReportVersion = 2
 )
 
+// GuestRequestVmmErrorStatus is the type of VMM error codes that are returned from a guest request.
+type GuestRequestVmmErrorStatus uint32
+
+const (
+	// VmmErrOk indicates that there are no VMM errors.
+	GuestRequestVmmOk GuestRequestVmmErrorStatus = iota
+	// GuestRequestVmmErrInvalidLen is a GHCB-specified value that
+	// the VMM can return in the upper 32 bits of EXIT_INFO_2
+	// during an extended guest request. This error indicates that
+	// the data buffer provided is not large enough to receive the
+	// data installed provided from the host device.
+	GuestRequestVmmErrInvalidLength = 1
+	// GuestRequestVmmErrBusy is a GHCB-specified value that the
+	// VMM can return in the upper 32 bits of EXIT_INFO_2 during a
+	// guest request. We use this error to retry messages after
+	// waiting an increasing amount of time.
+	GuestRequestVmmErrBusy = 2
+)
+
+// GuestRequestVmmErr is an error type for SevKvmErrStatus.
+type GuestRequestVmmErr struct {
+	error
+	Status GuestRequestVmmErrorStatus
+}
+
+func (e GuestRequestVmmErr) Error() string {
+	switch e.Status {
+	case GuestRequestVmmOk:
+		return "success"
+	case GuestRequestVmmErrInvalidLength:
+		return "data buffer length invalid"
+	case GuestRequestVmmErrBusy:
+		return "throttled"
+	default:
+		return fmt.Sprintf("[unknown: %d]", uint32(e.Status))
+	}
+}
+
 // CertTableHeaderEntry defines an entry of the beginning of an extended attestation report which
 // points to a specific key's certificate.
 type CertTableHeaderEntry struct {

--- a/abi/amdsp.go
+++ b/abi/amdsp.go
@@ -100,10 +100,6 @@ const (
 	// restoreRequired = 37
 )
 
-// GuestRequestInvalidLength is set by the ccp driver and not the AMD-SP when an guest extended
-// request provides too few pages for the firmware to populate with data.
-const GuestRequestInvalidLength SevFirmwareStatus = 0x100000000
-
 // SevFirmwareErr is an error that interprets firmware status codes from the AMD secure processor.
 type SevFirmwareErr struct {
 	error
@@ -167,9 +163,6 @@ func (e SevFirmwareErr) Error() string {
 	}
 	if e.Status == AeadOflow {
 		return "AMD-SP firmware memory would be over capacity for AEAD use"
-	}
-	if e.Status == GuestRequestInvalidLength {
-		return "too few extended guest request data pages"
 	}
 	return fmt.Sprintf("unexpected firmware status (see SEV API spec): %x", uint64(e.Status))
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -37,7 +37,7 @@ var tests []test.TestCase
 // Initializing a device with key generation is expensive. Just do it once for the test suite.
 func initDevice() {
 	now := time.Date(2022, time.May, 3, 9, 0, 0, 0, time.UTC)
-	tests := test.TestCases()
+	tests = test.TestCases()
 	ones32 := make([]byte, 32)
 	for i := range ones32 {
 		ones32[i] = 1
@@ -61,24 +61,26 @@ func TestOpenGetReportClose(t *testing.T) {
 	}
 	defer d.Close()
 	for _, tc := range tests {
-		reportProto := &spb.Report{}
-		if err := prototext.Unmarshal([]byte(tc.OutputProto), reportProto); err != nil {
-			t.Fatalf("test failure: %v", err)
-		}
-
-		// Does the proto report match expectations?
-		got, err := GetReport(d, tc.Input)
-		if err != tc.WantErr {
-			t.Fatalf("GetReport(d, %v) = %v, %v. Want err: %v", tc.Input, got, err, tc.WantErr)
-		}
-
-		if tc.WantErr == nil {
-			want := reportProto
-			want.Signature = got.Signature // Zeros were placeholders.
-			if diff := cmp.Diff(got, want, protocmp.Transform()); diff != "" {
-				t.Errorf("%s: GetReport(%v) expectation diff %s", tc.Name, tc.Input, diff)
+		t.Run(tc.Name, func(t *testing.T) {
+			reportProto := &spb.Report{}
+			if err := prototext.Unmarshal([]byte(tc.OutputProto), reportProto); err != nil {
+				t.Fatalf("test failure: %v", err)
 			}
-		}
+
+			// Does the proto report match expectations?
+			got, err := GetReport(d, tc.Input)
+			if !tc.Expect(err) {
+				t.Fatalf("GetReport(d, %v) = %v, %v. Want err: %v", tc.Input, got, err, tc.WantErr)
+			}
+
+			if tc.WantErr == "" {
+				want := reportProto
+				want.Signature = got.Signature // Zeros were placeholders.
+				if diff := cmp.Diff(got, want, protocmp.Transform()); diff != "" {
+					t.Errorf("GetReport(%v) expectation diff %s", tc.Input, diff)
+				}
+			}
+		})
 	}
 }
 
@@ -90,24 +92,26 @@ func TestOpenGetRawExtendedReportClose(t *testing.T) {
 	}
 	defer d.Close()
 	for _, tc := range tests {
-		raw, certs, err := GetRawExtendedReport(d, tc.Input)
-		if err != tc.WantErr {
-			t.Fatalf("%s: GetRawExtendedReport(d, %v) = %v, %v, %v. Want err: %v", tc.Name, tc.Input, raw, certs, err, tc.WantErr)
-		}
-		if tc.WantErr == nil {
-			got := abi.SignedComponent(raw)
-			want := abi.SignedComponent(tc.Output[:])
-			if !bytes.Equal(got, want) {
-				t.Errorf("%s: GetRawExtendedReport(%v) = {data: %v, certs: _} want %v", tc.Name, tc.Input, got, want)
+		t.Run(tc.Name, func(t *testing.T) {
+			raw, certs, err := GetRawExtendedReport(d, tc.Input)
+			if !tc.Expect(err) {
+				t.Fatalf("GetRawExtendedReport(d, %v) = %v, %v, %v. Want err: %v", tc.Input, raw, certs, err, tc.WantErr)
 			}
-			der, err := abi.ReportToSignatureDER(raw)
-			if err != nil {
-				t.Errorf("ReportToSignatureDER(%v) errored unexpectedly: %v", raw, err)
+			if tc.WantErr == "" {
+				got := abi.SignedComponent(raw)
+				want := abi.SignedComponent(tc.Output[:])
+				if !bytes.Equal(got, want) {
+					t.Errorf("GetRawExtendedReport(%v) = {data: %v, certs: _} want %v", tc.Input, got, want)
+				}
+				der, err := abi.ReportToSignatureDER(raw)
+				if err != nil {
+					t.Errorf("ReportToSignatureDER(%v) errored unexpectedly: %v", raw, err)
+				}
+				if err := d.Signer.Vcek.CheckSignature(x509.ECDSAWithSHA384, got, der); err != nil {
+					t.Errorf("signature with test keys did not verify: %v", err)
+				}
 			}
-			if err := d.Signer.Vcek.CheckSignature(x509.ECDSAWithSHA384, got, der); err != nil {
-				t.Errorf("signature with test keys did not verify: %v", err)
-			}
-		}
+		})
 	}
 }
 
@@ -119,36 +123,38 @@ func TestOpenGetExtendedReportClose(t *testing.T) {
 	}
 	defer d.Close()
 	for _, tc := range tests {
-		ereport, err := GetExtendedReport(d, tc.Input)
-		if err != tc.WantErr {
-			t.Fatalf("%s: GetExtendedReport(d, %v) = %v, %v. Want err: %v", tc.Name, tc.Input, ereport, err, tc.WantErr)
-		}
-		if tc.WantErr == nil {
-			reportProto := &spb.Report{}
-			if err := prototext.Unmarshal([]byte(tc.OutputProto), reportProto); err != nil {
-				t.Fatalf("test failure: %v", err)
+		t.Run(tc.Name, func(t *testing.T) {
+			ereport, err := GetExtendedReport(d, tc.Input)
+			if !tc.Expect(err) {
+				t.Fatalf("GetExtendedReport(d, %v) = %v, %v. Want err: %v", tc.Input, ereport, err, tc.WantErr)
 			}
+			if tc.WantErr == "" {
+				reportProto := &spb.Report{}
+				if err := prototext.Unmarshal([]byte(tc.OutputProto), reportProto); err != nil {
+					t.Fatalf("test failure: %v", err)
+				}
 
-			got := ereport.Report
-			want := reportProto
-			want.Signature = got.Signature // Zeros were placeholders.
-			if diff := cmp.Diff(got, want, protocmp.Transform()); diff != "" {
-				t.Errorf("%s: GetExtendedReport(%v) = {data: %v, certs: _} want %v. Diff: %s", tc.Name, tc.Input, got, want, diff)
-			}
+				got := ereport.Report
+				want := reportProto
+				want.Signature = got.Signature // Zeros were placeholders.
+				if diff := cmp.Diff(got, want, protocmp.Transform()); diff != "" {
+					t.Errorf("GetExtendedReport(%v) = {data: %v, certs: _} want %v. Diff: %s", tc.Input, got, want, diff)
+				}
 
-			if !bytes.Equal(ereport.GetCertificateChain().GetArkCert(), d.Signer.Ark.Raw) {
-				t.Errorf("ARK certificate mismatch. Got %v, want %v",
-					ereport.GetCertificateChain().GetArkCert(), d.Signer.Ark.Raw)
+				if !bytes.Equal(ereport.GetCertificateChain().GetArkCert(), d.Signer.Ark.Raw) {
+					t.Errorf("ARK certificate mismatch. Got %v, want %v",
+						ereport.GetCertificateChain().GetArkCert(), d.Signer.Ark.Raw)
+				}
+				if !bytes.Equal(ereport.GetCertificateChain().GetAskCert(), d.Signer.Ask.Raw) {
+					t.Errorf("ASK certificate mismatch. Got %v, want %v",
+						ereport.GetCertificateChain().GetAskCert(), d.Signer.Ask.Raw)
+				}
+				if !bytes.Equal(ereport.GetCertificateChain().GetVcekCert(), d.Signer.Vcek.Raw) {
+					t.Errorf("VCEK certificate mismatch. Got %v, want %v",
+						ereport.GetCertificateChain().GetVcekCert(), d.Signer.Vcek.Raw)
+				}
 			}
-			if !bytes.Equal(ereport.GetCertificateChain().GetAskCert(), d.Signer.Ask.Raw) {
-				t.Errorf("ASK certificate mismatch. Got %v, want %v",
-					ereport.GetCertificateChain().GetAskCert(), d.Signer.Ask.Raw)
-			}
-			if !bytes.Equal(ereport.GetCertificateChain().GetVcekCert(), d.Signer.Vcek.Raw) {
-				t.Errorf("VCEK certificate mismatch. Got %v, want %v",
-					ereport.GetCertificateChain().GetVcekCert(), d.Signer.Vcek.Raw)
-			}
-		}
+		})
 	}
 }
 

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -149,10 +149,10 @@ func TestSnpReportSignature(t *testing.T) {
 	for _, tc := range tests {
 		// Does the Raw report match expectations?
 		raw, err := sg.GetRawReport(d, tc.Input)
-		if err != tc.WantErr {
+		if !tc.Expect(err) {
 			t.Fatalf("GetRawReport(d, %v) = %v, %v. Want err: %v", tc.Input, raw, err, tc.WantErr)
 		}
-		if tc.WantErr == nil {
+		if tc.WantErr == "" {
 			got := abi.SignedComponent(raw)
 			want := abi.SignedComponent(tc.Output[:])
 			if !bytes.Equal(got, want) {
@@ -407,10 +407,10 @@ func TestOpenGetExtendedReportVerifyClose(t *testing.T) {
 		}}}}
 	for _, tc := range tests {
 		ereport, err := sg.GetExtendedReport(d, tc.Input)
-		if err != tc.WantErr {
+		if !tc.Expect(err) {
 			t.Fatalf("%s: GetExtendedReport(d, %v) = %v, %v. Want err: %v", tc.Name, tc.Input, ereport, err, tc.WantErr)
 		}
-		if tc.WantErr == nil {
+		if tc.WantErr == "" {
 			if err := SnpAttestation(ereport, options); err != nil {
 				t.Errorf("SnpAttestation(%v) errored unexpectedly: %v", ereport, err)
 			}


### PR DESCRIPTION
It's possible for the host to throttle the guest request calls since they synchronously use a shared resource: the secure processor.

If throttled, the VMM returns its result in the upper 32 bits of EXIT_INFO_2 in the GHCB. /dev/sev-guest returns the entire EXIT_INFO_2 as fw_err, (despite only the lower 32 bits meaning firmware errors). We check for the EBUSY error code in the upper 32 bits and use that information to try again with exponential backoff rather than error.

We call the EBUSY value checking legacy here because we expect to get an upstream patch into /dev/sev-guest to directly return -EAGAIN when it detects that it's been throttled.

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>