### PR TITLE
Replace interface{} with any

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -27,7 +27,7 @@ import (
 type Device interface {
 	Open(path string) error
 	Close() error
-	Ioctl(command uintptr, argument interface{}) (uintptr, error)
+	Ioctl(command uintptr, argument any) (uintptr, error)
 }
 
 func message(d Device, command uintptr, req *labi.SnpUserGuestRequest) error {

--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 //go:build linux || freebsd || openbsd || netbsd
-// +build linux freebsd openbsd netbsd
 
 // Package client provides an interface to the AMD SEV-SNP guest device commands.
 package client
@@ -64,7 +63,7 @@ func (d *LinuxDevice) Close() error {
 }
 
 // Ioctl sends a command with its wrapped request and response values to the Linux device.
-func (d *LinuxDevice) Ioctl(command uintptr, req interface{}) (uintptr, error) {
+func (d *LinuxDevice) Ioctl(command uintptr, req any) (uintptr, error) {
 	switch sreq := req.(type) {
 	case *labi.SnpUserGuestRequest:
 		abi := sreq.ABI()

--- a/client/client_macos.go
+++ b/client/client_macos.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build darwin
+//go:build darwin
 
 package client
 
@@ -39,6 +39,6 @@ func (d *MacOSDevice) Close() error {
 }
 
 // Ioctl is not supported on MacOS.
-func (d *MacOSDevice) Ioctl(command uintptr, req interface{}) (uintptr, error) {
+func (d *MacOSDevice) Ioctl(command uintptr, req any) (uintptr, error) {
 	return 0, fmt.Errorf("MacOS is unsupported")
 }

--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// +build windows
+//go:build windows
 
 package client
 
@@ -39,7 +39,7 @@ func (d *WindowsDevice) Close() error {
 }
 
 // Ioctl is not supported on Windows.
-func (d *WindowsDevice) Ioctl(command uintptr, req interface{}) (uintptr, error) {
+func (d *WindowsDevice) Ioctl(command uintptr, req any) (uintptr, error) {
 	// The GuestAttestation library on Windows is closed source.
 	return 0, fmt.Errorf("Windows is unsupported")
 }

--- a/testing/mocks.go
+++ b/testing/mocks.go
@@ -33,7 +33,7 @@ type GetReportResponse struct {
 // Device represents a sev-guest driver implementation with pre-programmed responses to commands.
 type Device struct {
 	isOpen        bool
-	ReportDataRsp map[string]interface{}
+	ReportDataRsp map[string]any
 	Keys          map[string][]byte
 	Certs         []byte
 	Signer        *AmdSigner
@@ -118,7 +118,7 @@ func (d *Device) getDerivedKey(req *labi.SnpDerivedKeyReqABI, rsp *labi.SnpDeriv
 }
 
 // Ioctl mocks commands with pre-specified responses for a finite number of requests.
-func (d *Device) Ioctl(command uintptr, req interface{}) (uintptr, error) {
+func (d *Device) Ioctl(command uintptr, req any) (uintptr, error) {
 	switch sreq := req.(type) {
 	case *labi.SnpUserGuestRequest:
 		switch command {

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -169,7 +169,7 @@ func TcDevice(tcs []TestCase, opts *DeviceOptions) (*Device, error) {
 	if err != nil {
 		return nil, fmt.Errorf("test failure creating certificates: %v", err)
 	}
-	responses := map[string]interface{}{}
+	responses := map[string]any{}
 	for _, tc := range tcs {
 		responses[hex.EncodeToString(tc.Input[:])] = &GetReportResponse{
 			Resp:     labi.SnpReportRespABI{Data: tc.Output},


### PR DESCRIPTION
The any type is the preferred way to handle arbitrary values.

This also cleans up old +build directives in favor of go:build.

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>