### PR TITLE
Change glog dependency to klog

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -22,11 +22,11 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/golang/glog"
 	pb "github.com/google/go-sev-guest/proto/sevsnp"
 	"github.com/pborman/uuid"
 	"golang.org/x/crypto/cryptobyte"
 	"golang.org/x/crypto/cryptobyte/asn1"
+	klog "k8s.io/klog/v2"
 )
 
 const (
@@ -676,15 +676,15 @@ func (c *CertTable) Proto() *pb.CertificateChain {
 	var err error
 	vcek, err = c.GetByGUIDString(VcekGUID)
 	if err != nil {
-		glog.Warningf("VCEK certificate not found in data pages: %v", err)
+		klog.Warningf("VCEK certificate not found in data pages: %v", err)
 	}
 	ask, err = c.GetByGUIDString(AskGUID)
 	if err != nil {
-		glog.Warningf("ASK certificate not found in data pages: %v", err)
+		klog.Warningf("ASK certificate not found in data pages: %v", err)
 	}
 	ark, err = c.GetByGUIDString(ArkGUID)
 	if err != nil {
-		glog.Warningf("ARK certificate not found in data pages: %v", err)
+		klog.Warningf("ARK certificate not found in data pages: %v", err)
 	}
 	return &pb.CertificateChain{
 		VcekCert: vcek,

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/google/go-sev-guest
 go 1.19
 
 require (
-	github.com/golang/glog v1.0.0
 	github.com/google/go-cmp v0.5.7
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/errors v0.9.1
@@ -11,9 +10,11 @@ require (
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
 	golang.org/x/sys v0.0.0-20220608164250-635b8c9b7f68
 	google.golang.org/protobuf v1.28.0
+	k8s.io/klog/v2 v2.80.1
 )
 
 require (
+	github.com/go-logr/logr v1.2.0 // indirect
 	github.com/google/uuid v1.0.0 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
 	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang/glog v1.0.0 h1:nfP3RFugxnNRyKgeWd4oI1nYvXpxrx8ck8ZrcizshdQ=
-github.com/golang/glog v1.0.0/go.mod h1:EWib/APOK0SL3dFbYqvxE3UYd8E6s1ouQ7iEp/0LWV4=
+github.com/go-logr/logr v1.2.0 h1:QK40JKJyMdUDz+h+xvCsru/bJhvG0UxvePV0ufL/AcE=
+github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
@@ -36,3 +36,5 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+k8s.io/klog/v2 v2.80.1 h1:atnLQ121W371wYYFawwYx1aEY2eUfs4l3J72wtgAwV4=
+k8s.io/klog/v2 v2.80.1/go.mod h1:y1WjHnz7Dj687irZUWR/WLkLc5N1YHtjLdmgWjndZn0=

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -28,13 +28,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/golang/glog"
 	"github.com/google/go-sev-guest/abi"
 	"github.com/google/go-sev-guest/kds"
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
 	"github.com/pborman/uuid"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	klog "k8s.io/klog/v2"
 )
 
 var (
@@ -112,7 +112,7 @@ func (r *AMDRootCerts) FromDER(ask []byte, ark []byte) error {
 
 	arkCert, err := x509.ParseCertificate(ark)
 	if err != nil {
-		glog.Errorf("could not parse ARK certificate: %v", err)
+		klog.Errorf("could not parse ARK certificate: %v", err)
 	}
 	r.ArkX509 = arkCert
 	return nil


### PR DESCRIPTION
glog is unmaintained, but the klog fork is.
Fixes #23

Signed-off-by: Dionna Glaze <dionnaglaze@google.com>