### PR TITLE
Minor fixes for go-tpm-tools hardware testing

### DIFF
--- a/testing/client/client.go
+++ b/testing/client/client.go
@@ -45,8 +45,10 @@ func GetSevGuest(tcs []test.TestCase, opts *test.DeviceOptions, tb testing.TB) (
 			"Milan": {
 				{
 					Product: "Milan",
-					AskX509: sevTestDevice.Signer.Ask,
-					ArkX509: sevTestDevice.Signer.Ark,
+					ProductCerts: &trust.ProductCerts{
+						Ask: sevTestDevice.Signer.Ask,
+						Ark: sevTestDevice.Signer.Ark,
+					},
 				},
 			},
 		}
@@ -54,9 +56,11 @@ func GetSevGuest(tcs []test.TestCase, opts *test.DeviceOptions, tb testing.TB) (
 			"Milan": {
 				{
 					Product: "Milan",
-					// Backwards, oops
-					AskX509: sevTestDevice.Signer.Ark,
-					ArkX509: sevTestDevice.Signer.Ask,
+					ProductCerts: &trust.ProductCerts{
+						// Backwards, oops
+						Ask: sevTestDevice.Signer.Ark,
+						Ark: sevTestDevice.Signer.Ask,
+					},
 				},
 			},
 		}
@@ -76,10 +80,12 @@ func GetSevGuest(tcs []test.TestCase, opts *test.DeviceOptions, tb testing.TB) (
 		// By flipping the ASK and ARK, we ensure that the attestation will never verify.
 		badSnpRoot[product] = []*trust.AMDRootCerts{{
 			Product: product,
-			ArkX509: rootCerts.AskX509,
-			AskX509: rootCerts.ArkX509,
-			AskSev:  rootCerts.ArkSev,
-			ArkSev:  rootCerts.AskSev,
+			ProductCerts: &trust.ProductCerts{
+				Ark: rootCerts.ProductCerts.Ask,
+				Ask: rootCerts.ProductCerts.Ark,
+			},
+			AskSev: rootCerts.ArkSev,
+			ArkSev: rootCerts.AskSev,
 		}}
 	}
 	return client, nil, badSnpRoot, test.GetKDS(tb)

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/go-sev-guest/tools/lib/cmdline"
 	"github.com/google/go-sev-guest/validate"
 	"github.com/google/go-sev-guest/verify"
+	"github.com/google/go-sev-guest/verify/testdata"
 	"github.com/google/go-sev-guest/verify/trust"
 	"github.com/google/logger"
 	"go.uber.org/multierr"
@@ -533,7 +534,10 @@ func main() {
 		if err != nil {
 			die(fmt.Errorf("could not read %q: %v", *testKdsFile, err))
 		}
-		kds := &testing.FakeKDS{Certs: &kpb.Certificates{}}
+		kds := &testing.FakeKDS{
+			Certs:       &kpb.Certificates{},
+			RootBundles: map[string]string{"Milan": string(testdata.MilanBytes)},
+		}
 		sopts.Getter = kds
 		if err := proto.Unmarshal(b, kds.Certs); err != nil {
 			die(fmt.Errorf("could not unmarshal KDS database: %v", err))

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -547,10 +547,12 @@ func main() {
 			if err == nil {
 				return false
 			}
-			if errors.As(err, &verify.AttestationRecreationErr{}) {
+			var certNetworkErr *trust.AttestationRecreationErr
+			var crlNetworkErr *verify.CRLUnavailableErr
+			if errors.As(err, &certNetworkErr) {
 				exitCode = exitCerts
 				return true
-			} else if errors.As(err, &verify.CRLUnavailableErr{}) {
+			} else if errors.As(err, &crlNetworkErr) {
 				exitCode = exitCrl
 				return true
 			}


### PR DESCRIPTION
These changes are part of some fixes I needed to make to go-sev-guest while modifying go-tpm-tools tests to run on SEV-SNP hardware.