### PR TITLE
Add KDS clock skew option to allow "future certs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ the ASK (intermediate signing key). The default option is to not check the CRL.
 Example expected invocation:
 
 ```
-verify.SnpAttestation(myAttestation, &verify.Options{})
+verify.SnpAttestation(myAttestation, verify.DefaultOptions())
 ```
 
 #### `Options` type

--- a/client/client_macos.go
+++ b/client/client_macos.go
@@ -27,7 +27,7 @@ const DefaultSevGuestDevicePath = "unknown"
 type MacOSDevice struct{}
 
 // Open is not supported on MacOS.
-func (d *MacOSDevice) Open(path string) error {
+func (_ *MacOSDevice) Open(_ string) error {
 	return fmt.Errorf("MacOS is unsupported")
 }
 
@@ -37,11 +37,11 @@ func OpenDevice() (*MacOSDevice, error) {
 }
 
 // Close is not supported on MacOS.
-func (d *MacOSDevice) Close() error {
+func (_ *MacOSDevice) Close() error {
 	return fmt.Errorf("MacOS is unsupported")
 }
 
 // Ioctl is not supported on MacOS.
-func (d *MacOSDevice) Ioctl(command uintptr, req any) (uintptr, error) {
+func (_ *MacOSDevice) Ioctl(_ uintptr, _ any) (uintptr, error) {
 	return 0, fmt.Errorf("MacOS is unsupported")
 }

--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -24,7 +24,7 @@ import (
 type WindowsDevice struct{}
 
 // Open is not supported on Windows.
-func (d *WindowsDevice) Open(path string) error {
+func (_ *WindowsDevice) Open(_ string) error {
 	return fmt.Errorf("Windows is unsupported")
 }
 
@@ -34,12 +34,12 @@ func OpenDevice() (*WindowsDevice, error) {
 }
 
 // Close is not supported on Windows.
-func (d *WindowsDevice) Close() error {
+func (_ *WindowsDevice) Close() error {
 	return fmt.Errorf("Windows is unsupported")
 }
 
 // Ioctl is not supported on Windows.
-func (d *WindowsDevice) Ioctl(command uintptr, req any) (uintptr, error) {
+func (_ *WindowsDevice) Ioctl(_ uintptr, _ any) (uintptr, error) {
 	// The GuestAttestation library on Windows is closed source.
 	return 0, fmt.Errorf("Windows is unsupported")
 }

--- a/client/linuxabi/linux_abi.go
+++ b/client/linuxabi/linux_abi.go
@@ -136,7 +136,7 @@ func (r *SnpReportReqABI) Pointer() unsafe.Pointer {
 }
 
 // Finish is a no-op.
-func (r *SnpReportReqABI) Finish(b BinaryConvertible) error { return nil }
+func (r *SnpReportReqABI) Finish(_ BinaryConvertible) error { return nil }
 
 // ABI returns the same object since it doesn't need a separate representation across the interface.
 func (r *SnpReportRespABI) ABI() BinaryConversion { return r }
@@ -147,7 +147,7 @@ func (r *SnpReportRespABI) Pointer() unsafe.Pointer {
 }
 
 // Finish checks the status of the message and translates it to a Golang error.
-func (r *SnpReportRespABI) Finish(b BinaryConvertible) error {
+func (r *SnpReportRespABI) Finish(_ BinaryConvertible) error {
 	if r.Status != 0 {
 		switch r.Status {
 		case 0x16: // Value from MSG_REPORT_RSP specification in SNP API.

--- a/testing/fake_certs.go
+++ b/testing/fake_certs.go
@@ -313,6 +313,13 @@ func (b *AmdSignerBuilder) CertChain() (*AmdSigner, error) {
 	if b.Product == "" {
 		b.Product = "Milan" // For terse tests.
 	}
+	if b.Keys == nil {
+		keys, err := DefaultAmdKeys()
+		if err != nil {
+			return nil, err
+		}
+		b.Keys = keys
+	}
 	if err := b.certifyArk(); err != nil {
 		return nil, fmt.Errorf("ark creation error: %v", err)
 	}

--- a/testing/mocks.go
+++ b/testing/mocks.go
@@ -42,7 +42,7 @@ type Device struct {
 }
 
 // Open changes the mock device's state to open.
-func (d *Device) Open(path string) error {
+func (d *Device) Open(_ string) error {
 	if d.isOpen {
 		return errors.New("device already open")
 	}
@@ -107,7 +107,7 @@ func DerivedKeyRequestToString(req *labi.SnpDerivedKeyReqABI) string {
 	return fmt.Sprintf("%x %x %x %x %x", req.RootKeySelect, req.GuestFieldSelect, req.Vmpl, req.GuestSVN, req.TCBVersion)
 }
 
-func (d *Device) getDerivedKey(req *labi.SnpDerivedKeyReqABI, rsp *labi.SnpDerivedKeyRespABI, fwErr *uint64) (uintptr, error) {
+func (d *Device) getDerivedKey(req *labi.SnpDerivedKeyReqABI, rsp *labi.SnpDerivedKeyRespABI, _ *uint64) (uintptr, error) {
 	if len(d.Keys) == 0 {
 		return 0, errors.New("test error: no keys")
 	}

--- a/tools/check/check.go
+++ b/tools/check/check.go
@@ -393,7 +393,7 @@ func setUInt32Value(value **wrapperspb.UInt32Value, name, flag string) error {
 	return err
 }
 
-func setString(dest *string, name, flag string, defaultValue string) {
+func setString(dest *string, _, flag string, defaultValue string) {
 	if flag == "" {
 		// Empty strings are not expected valid values, so override.
 		if !override() || *dest == "" {
@@ -435,7 +435,7 @@ func populateRootOfTrust() error {
 func populateConfig() error {
 	policy := config.Policy
 
-	setHashes := func(dest *[][]byte, name, flag string) error {
+	setHashes := func(dest *[][]byte, _, flag string) error {
 		if flag != "" {
 			hashes, err := parseHashes(flag)
 			if err != nil {
@@ -445,7 +445,7 @@ func populateConfig() error {
 		}
 		return nil
 	}
-	setCertBytes := func(dest *[][]byte, name, flag string) error {
+	setCertBytes := func(dest *[][]byte, _, flag string) error {
 		if flag != "" {
 			bytes, err := getCertBytes(flag)
 			if err != nil {

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -103,7 +103,7 @@ func lengthCheck(name string, length int, value []byte) error {
 }
 
 func checkOptionsLengths(opts *Options) error {
-	if err := multierr.Combine(
+	return multierr.Combine(
 		lengthCheck("family_id", abi.FamilyIDSize, opts.FamilyID),
 		lengthCheck("image_id", abi.ImageIDSize, opts.ImageID),
 		lengthCheck("report_data", abi.ReportDataSize, opts.ReportData),
@@ -111,10 +111,7 @@ func checkOptionsLengths(opts *Options) error {
 		lengthCheck("host_data", abi.HostDataSize, opts.HostData),
 		lengthCheck("report_id", abi.ReportIDSize, opts.ReportID),
 		lengthCheck("report_id_ma", abi.ReportIDMASize, opts.ReportIDMA),
-		lengthCheck("chip_id", abi.ChipIDSize, opts.ChipID)); err != nil {
-		return err
-	}
-	return nil
+		lengthCheck("chip_id", abi.ChipIDSize, opts.ChipID))
 }
 
 // Converts "maj.min" to its uint16 representation or errors.

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -246,7 +246,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		attestation, err := verify.GetAttestationFromReport(report, getter)
+		attestation, err := verify.GetAttestationFromReport(report, &verify.Options{Getter: getter})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -116,10 +116,7 @@ func validateAmdLocation(name pkix.Name, role string) error {
 	if err := checkSingletonList(name.Organization, "organization", "organizations", "Advanced Micro Devices"); err != nil {
 		return err
 	}
-	if err := checkSingletonList(name.OrganizationalUnit, "organizational unit", "organizational uints", "Engineering"); err != nil {
-		return err
-	}
-	return nil
+	return checkSingletonList(name.OrganizationalUnit, "organizational unit", "organizational uints", "Engineering")
 }
 
 func validateRootX509(product string, x *x509.Certificate, version int, role, cn string) error {


### PR DESCRIPTION
The KDS server system time is part of the VCEK certificates it generates and signs. It's possible for noticeable clock drift to lead to failed certificate verification despite having "fresh" certificates.

This patch adds a new DefaultOptions() function to provide a recommended Getter function and recommended allowable clock skew between the verifying system and AMD KDS.

With this change comes a mild refactor to some exported but uncommon functions to allow them more flexibility as we add options that can change their behavior.

*   GetAttestationFromReport's second argument is now a whole Options
    struct rather than just the Getter.
*   GetCrlAndCheckRoot similarly takes a whole Options instead of just
    the Getter.
*   X509Options takes a time.Time object to represent the current time.
*   VcekNotRevoked loses its second Getter argument and gains an
    *Options as its third argument.

The Golang x509 certificate verifier has a CurrentTime option to verify certificates against. If it's the zero time, then the library uses the system time with time.Now(). The added behavior for tolerating clock skew will use time.Sleep() for the difference in time if the added Now option is zero in order for system time to catch up. If Now is provided and is within the threshold amount of time to tolerate a certificate from the future, then we amend the CurrentTime to the certificate's NotBefore attribute to ensure that part of the certificate verifies.