### PR TITLE
Add a GoReleaser release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: release
+
+on:
+  push:
+    branches:
+    tags:
+      - 'v*'
+  pull_request:
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        go-version: [1.19.x]
+        os: [ubuntu-latest]
+
+    name: Release for (${{ matrix.os}}, Go ${{ matrix.go-version }})
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+          cache: true
+      - shell: bash
+        run: echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_ENV
+      - id: cache
+        uses: actions/cache@v3
+        with:
+          path: dist/${{ matrix.os }}
+          key: ${{ matrix.go }}-${{ env.sha_short }}
+      - name: Build all packages
+        run: go build -v ./...
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
+        if: success() && startsWith(github.ref, 'refs/tags/') && steps.cache.outputs.cache-hit != 'true'
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,52 @@
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+#      - windows
+#      - darwin
+    goarch:
+      - amd64
+    id: "attest"
+    main: ./tools/attest/attest.go
+    binary: attest
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+#      - windows
+#      - darwin
+    goarch:
+      - amd64
+    id: "check"
+    main: ./tools/check/check.go
+    binary: check
+    
+
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    # use zip for windows archives
+    format_overrides:
+    - goos: windows
+      format: zip
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj


### PR DESCRIPTION
This will build the tool CLI binaries and package them on release. For folks not writing Go libraries and just want the tools, this should make using them easier.

This of course isn't the best means of distribution since there is no Google signature of the releases, and no provenance attestation, but it can at least be confirmed through a GitHub authenticated channel.