### PR TITLE
Fix ASN1 type discrepancy in fake certificates

### DIFF
--- a/kds/kds.go
+++ b/kds/kds.go
@@ -237,10 +237,14 @@ func asn1U8(ext *pkix.Extension, field string, out *uint8) error {
 }
 
 func asn1IA5String(ext *pkix.Extension, field string, out *string) error {
-	if ext == nil {
+	if ext == nil || len(ext.Value) == 0 {
 		return fmt.Errorf("no extension for field %s", field)
 	}
-	rest, err := asn1.Unmarshal(ext.Value, out)
+	// Even with the "ia5" params, Unmarshal is too lax about string tags.
+	if ext.Value[0] != asn1.TagIA5String {
+		return fmt.Errorf("value is not tagged as an IA5String: %d", ext.Value[0])
+	}
+	rest, err := asn1.UnmarshalWithParams(ext.Value, out, "ia5")
 	if err != nil {
 		return fmt.Errorf("could not parse extension as an IA5String %v: %v", *ext, err)
 	}

--- a/testing/fake_certs.go
+++ b/testing/fake_certs.go
@@ -258,7 +258,7 @@ func (b *AmdSignerBuilder) certifyAsk() error {
 // for the given values.
 func CustomVcekExtensions(tcb kds.TCBParts, hwid [64]byte) []pkix.Extension {
 	asn1Zero, _ := asn1.Marshal(0)
-	productName, _ := asn1.Marshal("Milan-B0")
+	productName, _ := asn1.MarshalWithParams("Milan-B0", "ia5")
 	blSpl, _ := asn1.Marshal(int(tcb.BlSpl))
 	teeSpl, _ := asn1.Marshal(int(tcb.TeeSpl))
 	snpSpl, _ := asn1.Marshal(int(tcb.SnpSpl))

--- a/testing/fake_certs_test.go
+++ b/testing/fake_certs_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/google/go-sev-guest/abi"
+	"github.com/google/go-sev-guest/kds"
 	"github.com/pborman/uuid"
 )
 
@@ -65,5 +66,8 @@ func TestCertificatesParse(t *testing.T) {
 	}
 	if !hasArk {
 		t.Errorf("fake certs missing ARK")
+	}
+	if _, err := kds.VcekCertificateExtensions(signer.Vcek); err != nil {
+		t.Errorf("could not parse generated VCEK extensions: %v", err)
 	}
 }

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -173,7 +173,7 @@ func TestKdsMetadataLogic(t *testing.T) {
 	signMu.Do(initSigner)
 	trust.ClearProductCertCache()
 	asn1Zero, _ := asn1.Marshal(0)
-	productName, _ := asn1.Marshal("Cookie-B0")
+	productName, _ := asn1.MarshalWithParams("Cookie-B0", "ia5")
 	var hwid [64]byte
 	asn1Hwid, _ := asn1.Marshal(hwid[:])
 	tests := []struct {


### PR DESCRIPTION
Added a test to catch the error. Turns out UnmarshalWithParams doesn't make stricter type comparisons when given the "ia5" parameter string. MarshalWithParams does respect the params string.