### PR TITLE
Fix Issue#51 with new TCB validation

### DIFF
--- a/kds/kds.go
+++ b/kds/kds.go
@@ -216,6 +216,18 @@ func DecomposeTCBVersion(tcb TCBVersion) TCBParts {
 	}
 }
 
+// TCBPartsLE returns true iff all TCB components of tcb0 are <= the corresponding tcb1 components.
+func TCBPartsLE(tcb0, tcb1 TCBParts) bool {
+	return (tcb0.UcodeSpl <= tcb1.UcodeSpl) &&
+		(tcb0.SnpSpl <= tcb1.SnpSpl) &&
+		(tcb0.Spl7 <= tcb1.Spl7) &&
+		(tcb0.Spl6 <= tcb1.Spl6) &&
+		(tcb0.Spl5 <= tcb1.Spl5) &&
+		(tcb0.Spl4 <= tcb1.Spl4) &&
+		(tcb0.TeeSpl <= tcb1.TeeSpl) &&
+		(tcb0.BlSpl <= tcb1.BlSpl)
+}
+
 func asn1U8(ext *pkix.Extension, field string, out *uint8) error {
 	if ext == nil {
 		return fmt.Errorf("no extension for field %s", field)

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -311,7 +311,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 				PlatformInfo: &abi.SnpPlatformInfo{SMTEnabled: true},
 				MinimumTCB:   kds.TCBParts{UcodeSpl: 0xff, SnpSpl: 0x05, BlSpl: 0x02},
 			},
-			wantErr: "firmware's current TCB 9270000000007f1f is less than required",
+			wantErr: "the report's REPORTED_TCB {BlSpl:31 TeeSpl:127 Spl4:0 Spl5:0 Spl6:0 Spl7:0 SnpSpl:112 UcodeSpl:146} is lower than the policy minimum TCB {BlSpl:2 TeeSpl:0 Spl4:0 Spl5:0 Spl6:0 Spl7:0 SnpSpl:5 UcodeSpl:255} in at least one component",
 		},
 		{
 			name:        "Minimum build checked",
@@ -399,7 +399,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			name:        "rejected provisional by tcb",
 			attestation: attestationcb1455,
 			opts:        &Options{ReportData: noncecb1455[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
-			wantErr:     "firmware's committed TCB 9270000000007f00 does not match the current TCB 9270000000007f1f",
+			wantErr:     "the report's COMMITTED_TCB 0x9270000000007f00 does not match the report's CURRENT_TCB 0x9270000000007f1f",
 		},
 		{
 			name:        "accepted provisional by version",


### PR DESCRIPTION
Compare TCB versions component-wise with a new TCBPartsLE function that returns true iff all security patch levels (SPLs) of the TCB on the left are less than or equal to (LE) the corresponding SPLs on the right.

With this change comes a policy difference, not just a bug fix. To allow for fleet-wide reported TCBs to be lower than an individual node's committed TCB, I've relaxed some checks. The true floor of the expected TCB is only going to be the provided MinimumTCB. Internal relationships between TCB values are subject to change as we learn more how we're going to manage policies of VMs that have migrated with a migration agent.