### PR TITLE
Account for unexpected errors better in Match

### DIFF
--- a/testing/match.go
+++ b/testing/match.go
@@ -21,5 +21,5 @@ func Match(got error, want string) bool {
 	if got == nil {
 		return want == ""
 	}
-	return strings.Contains(got.Error(), want)
+	return want != "" && strings.Contains(got.Error(), want)
 }

--- a/verify/trust/trust.go
+++ b/verify/trust/trust.go
@@ -218,6 +218,7 @@ func (r *ProductCerts) X509Options(now time.Time) *x509.VerifyOptions {
 	roots.AddCert(r.Ark)
 	intermediates := x509.NewCertPool()
 	intermediates.AddCert(r.Ask)
+	fmt.Printf("but now is %s\n", now.Format(time.RFC3339))
 	return &x509.VerifyOptions{Roots: roots, Intermediates: intermediates, CurrentTime: now}
 }
 

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -382,6 +382,7 @@ func validateVcekCertificateProductSpecifics(r *trust.AMDRootCerts, cert *x509.C
 	if err := ValidateVcekCertIssuer(r, cert.Issuer); err != nil {
 		return err
 	}
+	fmt.Printf("now is %s\n", opts.Now.Format(time.RFC3339))
 	if _, err := cert.Verify(*r.X509Options(opts.Now)); err != nil {
 		return fmt.Errorf("error verifying VCEK certificate: %v (%v)", err, r.ProductCerts.Ask.IsCA)
 	}
@@ -527,6 +528,9 @@ func RootOfTrustToOptions(rot *cpb.RootOfTrust) (*Options, error) {
 func SnpAttestation(attestation *spb.Attestation, options *Options) error {
 	if options == nil {
 		return fmt.Errorf("options cannot be nil")
+	}
+	if attestation == nil {
+		return fmt.Errorf("attestation cannot be nil")
 	}
 	// Make sure we have the whole certificate chain if we're allowed.
 	if !options.DisableCertFetching {

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -303,7 +303,9 @@ func TestKdsMetadataLogic(t *testing.T) {
 					Ask: newSigner.Ask,
 				},
 			}},
-		}}
+		},
+			Now: time.Date(1, time.January, 5, 0, 0, 0, 0, time.UTC),
+		}
 		if tc.wantErr != "" {
 			options = &Options{}
 		}


### PR DESCRIPTION
SnpAttestation should also check both its inputs for nil. Thanks to Bandan Das for the report.