### PR TITLE
Fix 32-bit builds

### DIFF
--- a/abi/amdsp.go
+++ b/abi/amdsp.go
@@ -18,7 +18,7 @@ import "fmt"
 
 // SevFirmwareStatus is the type of all AMD-SP firmware status codes, as documented in the SEV API
 // https://www.amd.com/system/files/TechDocs/55766_SEV-KM_API_Specification.pdf
-type SevFirmwareStatus int
+type SevFirmwareStatus int64
 
 // Unexported errors are not expected to leave the kernel.
 const (


### PR DESCRIPTION
The SevFirmwareStatus type expects 64-bit values but has an underspecified type.

Fixes Issue#62