### PR TITLE
Make error when getting certificates more transparent for user

### DIFF
--- a/testing/mocks.go
+++ b/testing/mocks.go
@@ -151,12 +151,12 @@ func (d *Device) Product() *spb.SevProduct {
 	return d.SevProduct
 }
 
-// GetResponse controls how often (Occurances) a certain response should be
+// GetResponse controls how often (Occurrences) a certain response should be
 // provided.
 type GetResponse struct {
-	Occurances uint
-	Body       []byte
-	Error      error
+	Occurrences uint
+	Body        []byte
+	Error       error
 }
 
 // Getter is a mock for HTTPSGetter interface that sequentially
@@ -175,9 +175,9 @@ func SimpleGetter(responses map[string][]byte) *Getter {
 	for key, value := range responses {
 		getter.Responses[key] = []GetResponse{
 			{
-				Occurances: ^uint(0),
-				Body:       value,
-				Error:      nil,
+				Occurrences: ^uint(0),
+				Body:        value,
+				Error:       nil,
 			},
 		}
 	}
@@ -193,8 +193,8 @@ func (g *Getter) Get(url string) ([]byte, error) {
 	}
 	body := resp[0].Body
 	err := resp[0].Error
-	resp[0].Occurances--
-	if resp[0].Occurances == 0 {
+	resp[0].Occurrences--
+	if resp[0].Occurrences == 0 {
 		g.Responses[url] = resp[1:]
 	}
 	return body, err

--- a/testing/mocks.go
+++ b/testing/mocks.go
@@ -163,3 +163,31 @@ func (g *Getter) Get(url string) ([]byte, error) {
 	}
 	return v, nil
 }
+
+// VariableResponseGetter is a mock for HTTPSGetter interface that sequentially
+// returns the configured responses, independent of the provided URL.
+type VariableResponseGetter struct {
+	// callCount is used to return the respective responses
+	callCount     int
+	ResponseBody  [][]byte
+	ResponseError []error
+}
+
+// Get the next configured response body and error.
+func (g *VariableResponseGetter) Get(_ string) ([]byte, error) {
+	body := g.ResponseBody[g.callCount]
+	err := g.ResponseError[g.callCount]
+	g.callCount++
+	return body, err
+}
+
+// StringsToByteSlice helps to concisely construct the required ResponseBodies
+// for VariableResponseGetter.
+func StringsToByteSlice(strings ...string) [][]byte {
+	var result [][]byte
+	for idx := range strings {
+		s := strings[idx]
+		result = append(result, []byte(s))
+	}
+	return result
+}

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -235,12 +235,12 @@ func TestValidateSnpAttestation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	getter := &test.Getter{
-		Responses: map[string][]byte{
+	getter := test.SimpleGetter(
+		map[string][]byte{
 			"https://kdsintf.amd.com/vcek/v1/Milan/cert_chain": rootBytes,
 			"https://kdsintf.amd.com/vcek/v1/Milan/0a0b0c0d0e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010203040506?blSPL=31&teeSPL=127&snpSPL=112&ucodeSPL=146": sign.Vcek.Raw,
 		},
-	}
+	)
 	attestationFn := func(nonce [64]byte) *spb.Attestation {
 		report, err := sg.GetReport(device, nonce)
 		if err != nil {
@@ -271,12 +271,14 @@ func TestValidateSnpAttestation(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				return &spb.Attestation{Report: report,
+				return &spb.Attestation{
+					Report: report,
 					CertificateChain: &spb.CertificateChain{
 						AskCert:  sign0.Ask.Raw,
 						ArkCert:  sign0.Ark.Raw,
 						VcekCert: sign0.Vcek.Raw,
-					}}
+					},
+				}
 			}(),
 			opts: &Options{ReportData: nonce0s1[:], GuestPolicy: abi.SnpPolicy{Debug: true}},
 		},

--- a/verify/trust/trust_test.go
+++ b/verify/trust/trust_test.go
@@ -35,9 +35,9 @@ func TestRetryHTTPSGetter(t *testing.T) {
 				Responses: map[string][]test.GetResponse{
 					"https://fetch.me": {
 						{
-							Occurances: 1,
-							Body:       []byte("content"),
-							Error:      nil,
+							Occurrences: 1,
+							Body:        []byte("content"),
+							Error:       nil,
 						},
 					},
 				},
@@ -50,14 +50,14 @@ func TestRetryHTTPSGetter(t *testing.T) {
 				Responses: map[string][]test.GetResponse{
 					"https://fetch.me": {
 						{
-							Occurances: 1,
-							Body:       []byte(""),
-							Error:      errors.New("fail"),
+							Occurrences: 1,
+							Body:        []byte(""),
+							Error:       errors.New("fail"),
 						},
 						{
-							Occurances: 1,
-							Body:       []byte("content"),
-							Error:      nil,
+							Occurrences: 1,
+							Body:        []byte("content"),
+							Error:       nil,
 						},
 					},
 				},
@@ -70,14 +70,14 @@ func TestRetryHTTPSGetter(t *testing.T) {
 				Responses: map[string][]test.GetResponse{
 					"https://fetch.me": {
 						{
-							Occurances: 2,
-							Body:       []byte(""),
-							Error:      errors.New("fail"),
+							Occurrences: 2,
+							Body:        []byte(""),
+							Error:       errors.New("fail"),
 						},
 						{
-							Occurances: 1,
-							Body:       []byte("content"),
-							Error:      nil,
+							Occurrences: 1,
+							Body:        []byte("content"),
+							Error:       nil,
 						},
 					},
 				},
@@ -112,9 +112,9 @@ func TestRetryHTTPSGetterAllFail(t *testing.T) {
 		Responses: map[string][]test.GetResponse{
 			"https://fetch.me": {
 				{
-					Occurances: 1,
-					Body:       []byte(""),
-					Error:      errors.New("fail"),
+					Occurrences: 1,
+					Body:        []byte(""),
+					Error:       errors.New("fail"),
 				},
 			},
 		},

--- a/verify/trust/trust_test.go
+++ b/verify/trust/trust_test.go
@@ -26,12 +26,12 @@ import (
 
 func TestRetryHTTPSGetter(t *testing.T) {
 	testCases := map[string]struct {
-		getter        *test.VariableResponseGetter
+		getter        *test.Getter
 		timeout       time.Duration
 		maxRetryDelay time.Duration
 	}{
 		"immediate success": {
-			getter: &test.VariableResponseGetter{
+			getter: &test.Getter{
 				Responses: map[string][]test.GetResponse{
 					"https://fetch.me": {
 						{
@@ -46,7 +46,7 @@ func TestRetryHTTPSGetter(t *testing.T) {
 			maxRetryDelay: time.Millisecond,
 		},
 		"second success": {
-			getter: &test.VariableResponseGetter{
+			getter: &test.Getter{
 				Responses: map[string][]test.GetResponse{
 					"https://fetch.me": {
 						{
@@ -66,7 +66,7 @@ func TestRetryHTTPSGetter(t *testing.T) {
 			maxRetryDelay: time.Millisecond,
 		},
 		"third success": {
-			getter: &test.VariableResponseGetter{
+			getter: &test.Getter{
 				Responses: map[string][]test.GetResponse{
 					"https://fetch.me": {
 						{
@@ -108,7 +108,7 @@ func TestRetryHTTPSGetter(t *testing.T) {
 }
 
 func TestRetryHTTPSGetterAllFail(t *testing.T) {
-	testGetter := &test.VariableResponseGetter{
+	testGetter := &test.Getter{
 		Responses: map[string][]test.GetResponse{
 			"https://fetch.me": {
 				{

--- a/verify/trust/trust_test.go
+++ b/verify/trust/trust_test.go
@@ -1,0 +1,93 @@
+package trust
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+)
+
+// FakeHTTPSGetter is a test double for HTTPSGetter. It can hold a slice
+// of body and error responses so Get can be called multiple times and return
+// different values, as to simulate different scenarios.
+type FakeHTTPSGetter struct {
+	// callCount is used to return the respective responses
+	callCount     int
+	ResponseBody  [][]byte
+	ResponseError []error
+}
+
+// Get the next configured response body and error.
+func (f *FakeHTTPSGetter) Get(url string) ([]byte, error) {
+	body := f.ResponseBody[f.callCount]
+	err := f.ResponseError[f.callCount]
+	f.callCount++
+	return body, err
+}
+
+func stringsToByteSlice(strings ...string) [][]byte {
+	var result [][]byte
+	for idx := range strings {
+		s := strings[idx]
+		result = append(result, []byte(s))
+	}
+	return result
+}
+
+func TestRetryHTTPSGetterSuccess(t *testing.T) {
+	r := &RetryHTTPSGetter{
+		Timeout:       2 * time.Second,
+		MaxRetryDelay: 1 * time.Millisecond,
+		Getter: &FakeHTTPSGetter{
+			ResponseBody:  stringsToByteSlice("content"),
+			ResponseError: []error{nil},
+		},
+	}
+
+	body, err := r.Get("https://any.url")
+	if !bytes.Equal(body, []byte("content")) {
+		t.Errorf("expected '%s' but got '%s'", "content", body)
+	}
+	if err != nil {
+		t.Errorf("expected no error, but got %s", err.Error())
+	}
+}
+
+func TestRetryHTTPSGetterSecondSuccess(t *testing.T) {
+	r := &RetryHTTPSGetter{
+		Timeout:       2 * time.Second,
+		MaxRetryDelay: 1 * time.Millisecond,
+		Getter: &FakeHTTPSGetter{
+			ResponseBody:  stringsToByteSlice("", "content"),
+			ResponseError: []error{errors.New("failed"), nil},
+		},
+	}
+
+	body, err := r.Get("https://any.url")
+	if !bytes.Equal(body, []byte("content")) {
+		t.Errorf("expected '%s' but got '%s'", "content", body)
+	}
+	if err != nil {
+		t.Errorf("expected no error, but got %s", err.Error())
+	}
+}
+
+func TestRetryHTTPSGetterAllFail(t *testing.T) {
+	fail := errors.New("failed")
+	r := &RetryHTTPSGetter{
+		Timeout:       1 * time.Millisecond,
+		MaxRetryDelay: 1 * time.Millisecond,
+		Getter: &FakeHTTPSGetter{
+			ResponseBody:  stringsToByteSlice("", "", ""),
+			ResponseError: []error{fail, fail, fail},
+		},
+	}
+
+	body, err := r.Get("https://any.url")
+	if !bytes.Equal(body, []byte("")) {
+		t.Errorf("expected '%s' but got '%s'", "content", body)
+	}
+	if err == nil {
+		t.Errorf("expected error, but got none")
+	}
+}


### PR DESCRIPTION
As discussed in #69 , user should be informed about nature of error during HTTP get. Since `multierr` was already used in this project I opted for this solution.

I also added 3 unit tests.
Let me know if I missed anything, since the code involved sleeps I made sure to keep it simple.

`go test -count 100 ./verify/trust/` runs in 0.2s on my machine.