### PR TITLE
Fix `TrustedKeyKeys` typo

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -91,7 +91,7 @@ type Options struct {
 	// provided.
 	TrustedIDKeys []*x509.Certificate
 	// TrustedIDKeyHashes is an array of SHA-384 hashes of trusted ID signer keys's public key in
-	// SEV-SNP API format. Not required if TrustedKeyKeys is provided.
+	// SEV-SNP API format. Not required if TrustedIDKeys is provided.
 	TrustedIDKeyHashes [][]byte
 }
 


### PR DESCRIPTION
In the godoc of `TrustedIDKeyHashes`, it should say "Not required if **TrustedIDKeys** is provided." instead of "Not required if TrustedKeyKeys is provided.".