### PR TITLE
fix: Use reported TCB when fetching VCEK

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -615,7 +615,7 @@ func fillInAttestation(attestation *spb.Attestation, options *Options) error {
 		}
 	}
 	if len(chain.GetVcekCert()) == 0 {
-		vcekURL := kds.VCEKCertURL(product, report.GetChipId(), kds.TCBVersion(report.GetCurrentTcb()))
+		vcekURL := kds.VCEKCertURL(product, report.GetChipId(), kds.TCBVersion(report.GetReportedTcb()))
 		vcek, err := getter.Get(vcekURL)
 		if err != nil {
 			return &trust.AttestationRecreationErr{


### PR DESCRIPTION
### Proposed Change
Use the ReportedTCB when querying the AMD KDS for the VCEK certificate, as per [the specification](https://www.amd.com/content/dam/amd/en/documents/epyc-technical-docs/specifications/57230.pdf):
> The firmware maintains a TCB_VERSION called the ReportedTcb. ReportedTcb is used to derive
the VCEK that signs the attestation report.

### Additional Info
I've added no tests regarding this, since I don't know how a test could look like without adding additional testdata. If you are fine with adding additional testdata, I can add a test for the case of an report with mismatching `CurrentTCB` and `ReportedTCB`, which should trigger the bug from the issue mentioned below.

This fixes #72 