### PR TITLE
client: fix Windows builds

### DIFF
--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -47,6 +47,6 @@ func (*WindowsDevice) Ioctl(_ uintptr, _ any) (uintptr, error) {
 }
 
 // Product is not supported on Windows.
-func (*MacOSDevice) Product() *spb.SevProduct {
+func (*WindowsDevice) Product() *spb.SevProduct {
 	return &spb.SevProduct{}
 }


### PR DESCRIPTION
The library currently cannot be built for Windows due to a typo in the Windows-specific code. This fixes the issue.