### PR TITLE
Return after t.Skip()

### DIFF
--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -481,9 +481,11 @@ func TestOpenGetExtendedReportVerifyClose(t *testing.T) {
 			t.Run(tc.Name+"_"+getReport.name, func(t *testing.T) {
 				if getReport.skipVlek && tc.EK == test.KeyChoiceVlek {
 					t.Skip()
+					return
 				}
 				if getReport.vlekOnly && tc.EK != test.KeyChoiceVlek {
 					t.Skip()
+					return
 				}
 				ereport, err := getReport.getter(d, tc.Input)
 				if !test.Match(err, tc.WantErr) {


### PR DESCRIPTION
The skip call is just for noting in the test output that the test was skipped. We need to return from the test function to actually skip the testing logic.