### PR TITLE
Add DisableCertFetching verify_test mode

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -474,9 +474,12 @@ func decodeCerts(chain *spb.CertificateChain, key abi.ReportSigner, options *Opt
 	case abi.VlekReportSigner:
 		ek = chain.GetVlekCert()
 	}
+	if len(ek) == 0 {
+		return nil, nil, fmt.Errorf("missing %v certificate", key)
+	}
 	endorsementKeyCert, err := trust.ParseCert(ek)
 	if err != nil {
-		return nil, nil, fmt.Errorf("could not interpret %v DER bytes: %v", key, err)
+		return nil, nil, fmt.Errorf("could not interpret %v DER bytes %v: %v", key, ek, err)
 	}
 	exts, err := validateKDSCertificateProductNonspecific(endorsementKeyCert, key)
 	if err != nil {


### PR DESCRIPTION
Using test_kds=none can break some tests that have negative expectations on KDS behavior, so use the existing disable feature to test VCEK cert caching in specific tests.