### PR TITLE
Add product utility unit tests

### DIFF
--- a/kds/kds.go
+++ b/kds/kds.go
@@ -406,6 +406,9 @@ func preEndorsementKeyCertificateExtensions(cert *x509.Certificate) (*Extensions
 // VcekCertificateExtensions returns the x509v3 extensions from the KDS specification of a VCEK
 // certificate interpreted into a struct type.
 func VcekCertificateExtensions(cert *x509.Certificate) (*Extensions, error) {
+	if cert == nil {
+		return nil, fmt.Errorf("cert cannot be nil")
+	}
 	exts, err := preEndorsementKeyCertificateExtensions(cert)
 	if err != nil {
 		return nil, err
@@ -422,6 +425,9 @@ func VcekCertificateExtensions(cert *x509.Certificate) (*Extensions, error) {
 // VlekCertificateExtensions returns the x509v3 extensions from the KDS specification of a VLEK
 // certificate interpreted into a struct type.
 func VlekCertificateExtensions(cert *x509.Certificate) (*Extensions, error) {
+	if cert == nil {
+		return nil, fmt.Errorf("cert cannot be nil")
+	}
 	exts, err := preEndorsementKeyCertificateExtensions(cert)
 	if err != nil {
 		return nil, err

--- a/kds/kds_test.go
+++ b/kds/kds_test.go
@@ -218,6 +218,30 @@ func TestProductName(t *testing.T) {
 			},
 			want: "badstepping",
 		},
+		{
+			name: "unknown milan stepping",
+			input: &pb.SevProduct{
+				Name:            pb.SevProduct_SEV_PRODUCT_MILAN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 15},
+			},
+			want: "unmappedMilanStepping",
+		},
+		{
+			name: "unknown genoa stepping",
+			input: &pb.SevProduct{
+				Name:            pb.SevProduct_SEV_PRODUCT_GENOA,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 15},
+			},
+			want: "unmappedGenoaStepping",
+		},
+		{
+			name: "unknown",
+			input: &pb.SevProduct{
+				Name:            pb.SevProduct_SEV_PRODUCT_UNKNOWN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 15},
+			},
+			want: "Unknown",
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {
@@ -265,6 +289,12 @@ func TestParseProductName(t *testing.T) {
 			want: &pb.SevProduct{
 				Name: pb.SevProduct_SEV_PRODUCT_GENOA,
 			},
+		},
+		{
+			name:    "Unhandled report signer",
+			input:   "ignored",
+			key:     abi.NoneReportSigner,
+			wantErr: "internal: unhandled reportSigner",
 		},
 	}
 	for _, tc := range tcs {


### PR DESCRIPTION
Improves test coverage, but also expands GetAttestationFromReport to fill in the Product field of the Attestation message from the fetched VCEK/VLEK certificate's extension.