### PR TITLE
Fix SevProduct defaults for downstring testclient

### DIFF
--- a/testing/mocks.go
+++ b/testing/mocks.go
@@ -25,7 +25,6 @@ import (
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
-	"google.golang.org/protobuf/types/known/wrapperspb"
 )
 
 // GetReportResponse represents a mocked response to a command request.
@@ -144,10 +143,7 @@ func (d *Device) Ioctl(command uintptr, req any) (uintptr, error) {
 // Product returns the mocked product info or the default.
 func (d *Device) Product() *spb.SevProduct {
 	if d.SevProduct == nil {
-		return &spb.SevProduct{
-			Name:            spb.SevProduct_SEV_PRODUCT_MILAN,
-			MachineStepping: &wrapperspb.UInt32Value{Value: 0},
-		}
+		return abi.DefaultSevProduct()
 	}
 	return d.SevProduct
 }

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/go-sev-guest/abi"
 	labi "github.com/google/go-sev-guest/client/linuxabi"
 	"github.com/google/go-sev-guest/kds"
+	spb "github.com/google/go-sev-guest/proto/sevsnp"
 )
 
 // userZeros defines a ReportData example that is all zeros
@@ -151,15 +152,22 @@ func CreateRawReport(opts *TestReportOptions) [labi.SnpReportRespReportSize]byte
 
 // DeviceOptions specifies customizations for a fake sev-guest device.
 type DeviceOptions struct {
-	Keys   map[string][]byte
-	Now    time.Time
-	Signer *AmdSigner
+	Keys    map[string][]byte
+	Now     time.Time
+	Signer  *AmdSigner
+	Product *spb.SevProduct
 }
 
 func makeTestCerts(opts *DeviceOptions) ([]byte, *AmdSigner, error) {
 	signer := opts.Signer
+	var productString string
+	if opts.Product != nil {
+		productString = kds.ProductString(opts.Product)
+	} else {
+		productString = kds.DefaultProductString()
+	}
 	if signer == nil {
-		s, err := DefaultTestOnlyCertChain(kds.DefaultProductString(), opts.Now)
+		s, err := DefaultTestOnlyCertChain(productString, opts.Now)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -250,5 +258,6 @@ func TcDevice(tcs []TestCase, opts *DeviceOptions) (*Device, error) {
 		Certs:         certs,
 		Signer:        signer,
 		Keys:          opts.Keys,
+		SevProduct:    opts.Product,
 	}, nil
 }


### PR DESCRIPTION
go-tpm-tools can't cleanly upgrade to v0.9.2 since the mocks.go Product returns Milan-B0 but the abi default is Milan-B1. This breaks existing tests.

There was also a problem with fillInAttestation if the attestation already has a valid Product field set. This fixes the product guess to only happen with attestation.Product == nil.