### PR TITLE
Add configfs-tsm support for attestation reports

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -493,6 +493,27 @@ func ReportToProto(data []uint8) (*pb.Report, error) {
 	return r, nil
 }
 
+// ReportCertsToProto creates a pb.Attestation from the report and certificate table represented in
+// data. The report is expected to take exactly abi.ReportSize bytes, followed by the certificate
+// table.
+func ReportCertsToProto(data []uint8) (*pb.Attestation, error) {
+	var certs []uint8
+	report := data
+	if len(data) >= ReportSize {
+		report = data[:ReportSize]
+		certs = data[ReportSize:]
+	}
+	mreport, err := ReportToProto(report)
+	if err != nil {
+		return nil, err
+	}
+	table := new(CertTable)
+	if err := table.Unmarshal(certs); err != nil {
+		return nil, err
+	}
+	return &pb.Attestation{Report: mreport, CertificateChain: table.Proto()}, nil
+}
+
 func checkReportSizes(r *pb.Report) error {
 	if len(r.FamilyId) != FamilyIDSize {
 		return fmt.Errorf("report family_id length is %d, expect %d", len(r.FamilyId), FamilyIDSize)

--- a/client/client.go
+++ b/client/client.go
@@ -39,6 +39,19 @@ type Device interface {
 	Product() *pb.SevProduct
 }
 
+// LeveledQuoteProvider encapsulates calls to collect an extended attestation report at a given
+// privilege level.
+type LeveledQuoteProvider interface {
+	IsSupported() bool
+	GetRawQuoteAtLevel(reportData [64]byte, vmpl uint) ([]uint8, error)
+}
+
+// QuoteProvider encapsulates calls to collect an extended attestation report.
+type QuoteProvider interface {
+	IsSupported() bool
+	GetRawQuote(reportData [64]byte) ([]uint8, error)
+}
+
 // UseDefaultSevGuest returns true iff -sev_guest_device_path=default.
 func UseDefaultSevGuest() bool {
 	return *sevGuestPath == "default"

--- a/client/client_macos.go
+++ b/client/client_macos.go
@@ -26,6 +26,7 @@ import (
 const DefaultSevGuestDevicePath = "unknown"
 
 // MacOSDevice implements the Device interface with Linux ioctls.
+// Deprecated: Use MacOSQuoteProvider.
 type MacOSDevice struct{}
 
 // Open is not supported on MacOS.
@@ -51,4 +52,32 @@ func (*MacOSDevice) Ioctl(_ uintptr, _ any) (uintptr, error) {
 // Product is not supported on MacOS.
 func (*MacOSDevice) Product() *spb.SevProduct {
 	return &spb.SevProduct{}
+}
+
+// MacOSQuoteProvider implements the QuoteProvider interface with Linux's configfs-tsm.
+type MacOSQuoteProvider struct{}
+
+// IsSupported checks if the quote provider is supported.
+func (*MacOSQuoteProvider) IsSupported() bool {
+	return false
+}
+
+// GetRawQuote returns byte format attestation plus certificate table via ConfigFS.
+func (*MacOSQuoteProvider) GetRawQuote(reportData [64]byte) ([]byte, error) {
+	return nil, fmt.Errorf("MacOS is unsupported")
+}
+
+// GetRawQuoteAtLevel returns byte format attestation plus certificate table via ConfigFS.
+func (*MacOSQuoteProvider) GetRawQuoteAtLevel(reportData [64]byte, level uint) ([]byte, error) {
+	return nil, fmt.Errorf("MacOS is unsupported")
+}
+
+// GetQuoteProvider returns a supported SEV-SNP QuoteProvider.
+func GetQuoteProvider() (QuoteProvider, error) {
+	return nil, fmt.Errorf("MacOS is unsupported")
+}
+
+// GetLeveledQuoteProvider returns a supported SEV-SNP LeveledQuoteProvider.
+func GetLeveledQuoteProvider() (LeveledQuoteProvider, error) {
+	return nil, fmt.Errorf("MacOS is unsupported")
 }

--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -23,6 +23,7 @@ import (
 )
 
 // WindowsDevice implements the Device interface with Linux ioctls.
+// Deprecated: Use WindowsQuoteProvider.
 type WindowsDevice struct{}
 
 // Open is not supported on Windows.
@@ -49,4 +50,32 @@ func (*WindowsDevice) Ioctl(_ uintptr, _ any) (uintptr, error) {
 // Product is not supported on Windows.
 func (*WindowsDevice) Product() *spb.SevProduct {
 	return &spb.SevProduct{}
+}
+
+// WindowsQuoteProvider implements the QuoteProvider interface with Linux's configfs-tsm.
+type WindowsQuoteProvider struct{}
+
+// IsSupported checks if the quote provider is supported.
+func (*WindowsQuoteProvider) IsSupported() bool {
+	return false
+}
+
+// GetRawQuote returns byte format attestation plus certificate table via ConfigFS.
+func (*WindowsQuoteProvider) GetRawQuote(reportData [64]byte) ([]byte, error) {
+	return nil, fmt.Errorf("Windows is unsupported")
+}
+
+// GetRawQuoteAtLevel returns byte format attestation plus certificate table via ConfigFS.
+func (*WindowsQuoteProvider) GetRawQuoteAtLevel(reportData [64]byte, level uint) ([]byte, error) {
+	return nil, fmt.Errorf("Windows is unsupported")
+}
+
+// GetQuoteProvider returns a supported SEV-SNP QuoteProvider.
+func GetQuoteProvider() (QuoteProvider, error) {
+	return nil, fmt.Errorf("Windows is unsupported")
+}
+
+// GetLeveledQuoteProvider returns a supported SEV-SNP LeveledQuoteProvider.
+func GetLeveledQuoteProvider() (LeveledQuoteProvider, error) {
+	return nil, fmt.Errorf("Windows is unsupported")
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.19
 require (
 	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.5.7
+	github.com/google/go-configfs-tsm v0.2.2
 	github.com/google/logger v1.1.1
 	github.com/pborman/uuid v1.2.1
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.7 h1:81/ik6ipDQS2aGcBfIN5dHDB36BwrStyeAQquSYCV4o=
 github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8/DtOE=
+github.com/google/go-configfs-tsm v0.2.2 h1:YnJ9rXIOj5BYD7/0DNnzs8AOp7UcvjfTvt215EWcs98=
+github.com/google/go-configfs-tsm v0.2.2/go.mod h1:EL1GTDFMb5PZQWDviGfZV9n87WeGTR/JUg13RfwkgRo=
 github.com/google/logger v1.1.1 h1:+6Z2geNxc9G+4D4oDO9njjjn2d0wN5d7uOo0vOIW1NQ=
 github.com/google/logger v1.1.1/go.mod h1:BkeJZ+1FhQ+/d087r4dzojEg1u2ZX+ZqG1jTUrLM+zQ=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -261,3 +261,24 @@ func TcDevice(tcs []TestCase, opts *DeviceOptions) (*Device, error) {
 		SevProduct:    opts.Product,
 	}, nil
 }
+
+// TcQuoteProvider returns a mock quote provider populated from test cases' inputs and expected outputs.
+func TcQuoteProvider(tcs []TestCase, opts *DeviceOptions) (*QuoteProvider, error) {
+	certs, signer, err := makeTestCerts(opts)
+	if err != nil {
+		return nil, fmt.Errorf("test failure creating certificates: %v", err)
+	}
+	responses := map[string]any{}
+	for _, tc := range tcs {
+		responses[hex.EncodeToString(tc.Input[:])] = &GetReportResponse{
+			Resp:  labi.SnpReportRespABI{Data: tc.Output},
+			FwErr: tc.FwErr,
+		}
+	}
+	return &QuoteProvider{
+		ReportDataRsp: responses,
+		Certs:         certs,
+		Signer:        signer,
+		SevProduct:    opts.Product,
+	}, nil
+}


### PR DESCRIPTION
Given Dan Williams's configfs-tsm patch set to the Linux kernel, all attestation reports ought to be requested through configfs and not ioctls.

This marks the deprecation of the Device interface for reports, but not for keys.

Tested locally with go-tpm-tools. Should be an easy update.