### PR TITLE
Add Deprecated: notes and add proto helpers.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -42,14 +42,22 @@ type Device interface {
 // LeveledQuoteProvider encapsulates calls to collect an extended attestation report at a given
 // privilege level.
 type LeveledQuoteProvider interface {
+	// IsSupported returns whether the kernel supports this implementation.
 	IsSupported() bool
+	// GetRawQuote returns a raw report with the given privilege level.
 	GetRawQuoteAtLevel(reportData [64]byte, vmpl uint) ([]uint8, error)
+	// Product returns AMD SEV-related CPU information of the calling CPU.
+	Product() *pb.SevProduct
 }
 
 // QuoteProvider encapsulates calls to collect an extended attestation report.
 type QuoteProvider interface {
+	// IsSupported returns whether the kernel supports this implementation.
 	IsSupported() bool
+	// GetRawQuote returns a raw report with the default privilege level.
 	GetRawQuote(reportData [64]byte) ([]uint8, error)
+	// Product returns AMD SEV-related CPU information of the calling CPU.
+	Product() *pb.SevProduct
 }
 
 // UseDefaultSevGuest returns true iff -sev_guest_device_path=default.
@@ -76,6 +84,8 @@ func message(d Device, command uintptr, req *labi.SnpUserGuestRequest) error {
 
 // GetRawReportAtVmpl requests for an attestation report at the given VMPL that incorporates the
 // given user data.
+//
+// Deprecated: Use LeveledQuoteProvider.
 func GetRawReportAtVmpl(d Device, reportData [64]byte, vmpl int) ([]byte, error) {
 	var snpReportRsp labi.SnpReportRespABI
 	userGuestReq := labi.SnpUserGuestRequest{
@@ -92,11 +102,15 @@ func GetRawReportAtVmpl(d Device, reportData [64]byte, vmpl int) ([]byte, error)
 }
 
 // GetRawReport requests for an attestation report at VMPL0 that incorporates the given user data.
+//
+// Deprecated: Use QuoteProvider.
 func GetRawReport(d Device, reportData [64]byte) ([]byte, error) {
 	return GetRawReportAtVmpl(d, reportData, 0)
 }
 
 // GetReportAtVmpl gets an attestation report at the given VMPL into its protobuf representation.
+//
+// Deprecated: Use GetQuoteProtoAtLevel.
 func GetReportAtVmpl(d Device, reportData [64]byte, vmpl int) (*pb.Report, error) {
 	data, err := GetRawReportAtVmpl(d, reportData, vmpl)
 	if err != nil {
@@ -106,6 +120,8 @@ func GetReportAtVmpl(d Device, reportData [64]byte, vmpl int) (*pb.Report, error
 }
 
 // GetReport gets an attestation report at VMPL0 into its protobuf representation.
+//
+// Deprecated: Use GetQuoteProto.
 func GetReport(d Device, reportData [64]byte) (*pb.Report, error) {
 	return GetReportAtVmpl(d, reportData, 0)
 }
@@ -152,6 +168,8 @@ func queryCertificateLength(d Device, vmpl int) (uint32, error) {
 
 // GetRawExtendedReportAtVmpl requests for an attestation report that incorporates the given user
 // data at the given VMPL, and additional key certificate information.
+//
+// Deprecated: Use LeveledQuoteProvider.
 func GetRawExtendedReportAtVmpl(d Device, reportData [64]byte, vmpl int) ([]byte, []byte, error) {
 	length, err := queryCertificateLength(d, vmpl)
 	if err != nil {
@@ -167,11 +185,47 @@ func GetRawExtendedReportAtVmpl(d Device, reportData [64]byte, vmpl int) ([]byte
 
 // GetRawExtendedReport requests for an attestation report that incorporates the given user data,
 // and additional key certificate information.
+//
+// Deprecated: Use QuoteProvider.
 func GetRawExtendedReport(d Device, reportData [64]byte) ([]byte, []byte, error) {
 	return GetRawExtendedReportAtVmpl(d, reportData, 0)
 }
 
+// GetQuoteProto uses the given QuoteProvider to return the
+// protobuf representation of an attestation report with cached
+// certificate chain.
+func GetQuoteProto(qp QuoteProvider, reportData [64]byte) (*pb.Attestation, error) {
+	reportcerts, err := qp.GetRawQuote(reportData)
+	if err != nil {
+		return nil, err
+	}
+	attestation, err := abi.ReportCertsToProto(reportcerts)
+	if err != nil {
+		return nil, err
+	}
+	attestation.Product = qp.Product()
+	return attestation, nil
+}
+
+// GetQuoteProtoAtLevel uses the given LeveledQuoteProvider to return the
+// protobuf representation of an attestation report at a given VMPL with cached
+// certificate chain.
+func GetQuoteProtoAtLevel(qp LeveledQuoteProvider, reportData [64]byte, vmpl uint) (*pb.Attestation, error) {
+	reportcerts, err := qp.GetRawQuoteAtLevel(reportData, vmpl)
+	if err != nil {
+		return nil, err
+	}
+	attestation, err := abi.ReportCertsToProto(reportcerts)
+	if err != nil {
+		return nil, err
+	}
+	attestation.Product = qp.Product()
+	return attestation, nil
+}
+
 // GetExtendedReportAtVmpl gets an extended attestation report at the given VMPL into a structured type.
+//
+// Deprecated: Use GetQuoteProtoAtLevel
 func GetExtendedReportAtVmpl(d Device, reportData [64]byte, vmpl int) (*pb.Attestation, error) {
 	reportBytes, certBytes, err := GetRawExtendedReportAtVmpl(d, reportData, vmpl)
 	if err != nil {
@@ -195,6 +249,8 @@ func GetExtendedReportAtVmpl(d Device, reportData [64]byte, vmpl int) (*pb.Attes
 }
 
 // GetExtendedReport gets an extended attestation report at VMPL0 into a structured type.
+//
+// Deprecated: Use GetQuoteProto.
 func GetExtendedReport(d Device, reportData [64]byte) (*pb.Attestation, error) {
 	return GetExtendedReportAtVmpl(d, reportData, 0)
 }

--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -168,6 +168,11 @@ func (p *LinuxIoctlQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, err
 	return append(report, certs...), nil
 }
 
+// Product returns the current CPU's associated AMD SEV product information.
+func (*LinuxIoctlQuoteProvider) Product() *spb.SevProduct {
+	return abi.SevProduct()
+}
+
 // LinuxConfigFsQuoteProvider implements the QuoteProvider interface to fetch
 // attestation quote via ConfigFS.
 type LinuxConfigFsQuoteProvider struct{}
@@ -207,6 +212,11 @@ func (p *LinuxConfigFsQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, 
 	return append(resp.OutBlob, resp.AuxBlob...), nil
 }
 
+// Product returns the current CPU's associated AMD SEV product information.
+func (*LinuxConfigFsQuoteProvider) Product() *spb.SevProduct {
+	return abi.SevProduct()
+}
+
 // GetQuoteProvider returns a supported SEV-SNP QuoteProvider.
 func GetQuoteProvider() (QuoteProvider, error) {
 	preferred := &LinuxConfigFsQuoteProvider{}
@@ -217,7 +227,7 @@ func GetQuoteProvider() (QuoteProvider, error) {
 }
 
 // GetLeveledQuoteProvider returns a supported SEV-SNP LeveledQuoteProvider.
-func GetLeveledQuoteProvider() (QuoteProvider, error) {
+func GetLeveledQuoteProvider() (LeveledQuoteProvider, error) {
 	preferred := &LinuxConfigFsQuoteProvider{}
 	if !preferred.IsSupported() {
 		return &LinuxIoctlQuoteProvider{}, nil

--- a/client/client_macos.go
+++ b/client/client_macos.go
@@ -26,7 +26,6 @@ import (
 const DefaultSevGuestDevicePath = "unknown"
 
 // MacOSDevice implements the Device interface with Linux ioctls.
-// Deprecated: Use MacOSQuoteProvider.
 type MacOSDevice struct{}
 
 // Open is not supported on MacOS.

--- a/client/client_windows.go
+++ b/client/client_windows.go
@@ -23,7 +23,6 @@ import (
 )
 
 // WindowsDevice implements the Device interface with Linux ioctls.
-// Deprecated: Use WindowsQuoteProvider.
 type WindowsDevice struct{}
 
 // Open is not supported on Windows.

--- a/testing/client/client.go
+++ b/testing/client/client.go
@@ -120,9 +120,9 @@ func GetSevQuoteProvider(tcs []test.TestCase, opts *test.DeviceOptions, tb testi
 				{
 					Product: "Milan",
 					ProductCerts: &trust.ProductCerts{
-						Ask:  sevQp.Signer.Ask,
-						Ark:  sevQp.Signer.Ark,
-						Asvk: sevQp.Signer.Asvk,
+						Ask:  sevQp.Device.Signer.Ask,
+						Ark:  sevQp.Device.Signer.Ark,
+						Asvk: sevQp.Device.Signer.Asvk,
 					},
 				},
 			},
@@ -133,14 +133,14 @@ func GetSevQuoteProvider(tcs []test.TestCase, opts *test.DeviceOptions, tb testi
 					Product: "Milan",
 					ProductCerts: &trust.ProductCerts{
 						// No ASK, oops.
-						Ask:  sevQp.Signer.Ark,
-						Ark:  sevQp.Signer.Ark,
-						Asvk: sevQp.Signer.Ark,
+						Ask:  sevQp.Device.Signer.Ark,
+						Ark:  sevQp.Device.Signer.Ark,
+						Asvk: sevQp.Device.Signer.Ark,
 					},
 				},
 			},
 		}
-		fakekds, err := test.FakeKDSFromSigner(sevQp.Signer)
+		fakekds, err := test.FakeKDSFromSigner(sevQp.Device.Signer)
 		if err != nil {
 			tb.Fatalf("failed to create fake KDS from signer: %v", err)
 		}

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -162,7 +162,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	device0, err := test.TcDevice(test.TestCases(), &test.DeviceOptions{Now: now, Signer: sign0})
+	qp0, err := test.TcQuoteProvider(test.TestCases(), &test.DeviceOptions{Now: now, Signer: sign0})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -243,7 +243,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			}(),
 		},
 	}
-	device, err := test.TcDevice(tcs, opts)
+	qp, err := test.TcQuoteProvider(tcs, opts)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -254,10 +254,12 @@ func TestValidateSnpAttestation(t *testing.T) {
 		},
 	)
 	attestationFn := func(nonce [64]byte) *spb.Attestation {
-		report, err := sg.GetReport(device, nonce)
+
+		q, err := sg.GetQuoteProto(qp, nonce)
 		if err != nil {
 			t.Fatal(err)
 		}
+		report := q.Report
 		attestation, err := verify.GetAttestationFromReport(report, &verify.Options{Getter: getter})
 		if err != nil {
 			t.Fatal(err)
@@ -279,10 +281,11 @@ func TestValidateSnpAttestation(t *testing.T) {
 		{
 			name: "just reportData",
 			attestation: func() *spb.Attestation {
-				report, err := sg.GetReport(device0, nonce0s1)
+				q, err := sg.GetQuoteProto(qp0, nonce0s1)
 				if err != nil {
 					t.Fatal(err)
 				}
+				report := q.Report
 				return &spb.Attestation{
 					Report: report,
 					CertificateChain: &spb.CertificateChain{


### PR DESCRIPTION
Add Product() as a required method for the quote provider interfaces. Closes #100.