### PR TITLE
Add SevProduct raw cert representation.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -47,6 +47,8 @@ type LeveledQuoteProvider interface {
 	// GetRawQuote returns a raw report with the given privilege level.
 	GetRawQuoteAtLevel(reportData [64]byte, vmpl uint) ([]uint8, error)
 	// Product returns AMD SEV-related CPU information of the calling CPU.
+	//
+	// Deprecated: Use abi.ExtraPlatformInfoGUID in raw quote certificate table.
 	Product() *pb.SevProduct
 }
 
@@ -57,6 +59,8 @@ type QuoteProvider interface {
 	// GetRawQuote returns a raw report with the default privilege level.
 	GetRawQuote(reportData [64]byte) ([]uint8, error)
 	// Product returns AMD SEV-related CPU information of the calling CPU.
+	//
+	// Deprecated: Use abi.ExtraPlatformInfoGUID in the raw quote certificate table.
 	Product() *pb.SevProduct
 }
 
@@ -203,6 +207,7 @@ func GetQuoteProto(qp QuoteProvider, reportData [64]byte) (*pb.Attestation, erro
 	if err != nil {
 		return nil, err
 	}
+	// TODO(Issue#109): Remove when Product is removed.
 	attestation.Product = qp.Product()
 	return attestation, nil
 }

--- a/client/client_linux.go
+++ b/client/client_linux.go
@@ -157,7 +157,12 @@ func (p *LinuxIoctlQuoteProvider) GetRawQuoteAtLevel(reportData [64]byte, level 
 	if err != nil {
 		return nil, err
 	}
-	return append(report, certs...), nil
+	// Mix the platform info in with the auxblob.
+	extended, err := abi.ExtendedPlatformCertTable(certs)
+	if err != nil {
+		return nil, fmt.Errorf("invalid certificate table: %v", err)
+	}
+	return append(report, extended...), nil
 }
 
 // GetRawQuote returns byte format attestation plus certificate table via /dev/sev-guest ioctl.
@@ -166,6 +171,8 @@ func (p *LinuxIoctlQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, err
 }
 
 // Product returns the current CPU's associated AMD SEV product information.
+//
+// Deprecated: Use ExtraPlatformInfoGUID from the cert table.
 func (*LinuxIoctlQuoteProvider) Product() *spb.SevProduct {
 	return abi.SevProduct()
 }
@@ -193,7 +200,12 @@ func (p *LinuxConfigFsQuoteProvider) GetRawQuoteAtLevel(reportData [64]byte, lev
 	if err != nil {
 		return nil, err
 	}
-	return append(resp.OutBlob, resp.AuxBlob...), nil
+	// Mix the platform info in with the auxblob.
+	extended, err := abi.ExtendedPlatformCertTable(resp.AuxBlob)
+	if err != nil {
+		return nil, fmt.Errorf("invalid certificate table: %v", err)
+	}
+	return append(resp.OutBlob, extended...), nil
 }
 
 // GetRawQuote returns byte format attestation plus certificate table via ConfigFS.
@@ -206,10 +218,17 @@ func (p *LinuxConfigFsQuoteProvider) GetRawQuote(reportData [64]byte) ([]uint8, 
 	if err != nil {
 		return nil, err
 	}
-	return append(resp.OutBlob, resp.AuxBlob...), nil
+	// Mix the platform info in with the auxblob.
+	extended, err := abi.ExtendedPlatformCertTable(resp.AuxBlob)
+	if err != nil {
+		return nil, fmt.Errorf("invalid certificate table: %v", err)
+	}
+	return append(resp.OutBlob, extended...), nil
 }
 
 // Product returns the current CPU's associated AMD SEV product information.
+//
+// Deprecated: Use ExtraPlatformInfoGUID from the cert table.
 func (*LinuxConfigFsQuoteProvider) Product() *spb.SevProduct {
 	return abi.SevProduct()
 }

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -24,6 +24,7 @@ import (
 	labi "github.com/google/go-sev-guest/client/linuxabi"
 	"github.com/google/go-sev-guest/kds"
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
+	"github.com/google/logger"
 )
 
 // userZeros defines a ReportData example that is all zeros
@@ -253,12 +254,17 @@ func TcDevice(tcs []TestCase, opts *DeviceOptions) (*Device, error) {
 			EsResult: tc.EsResult,
 		}
 	}
+	product := opts.Product
+	if product == nil {
+		logger.Warning("test missing sevproduct")
+		product = abi.DefaultSevProduct()
+	}
 	return &Device{
 		ReportDataRsp: responses,
 		Certs:         certs,
 		Signer:        signer,
 		Keys:          opts.Keys,
-		SevProduct:    opts.Product,
+		SevProduct:    product,
 	}, nil
 }
 

--- a/tools/check/check_test.go
+++ b/tools/check/check_test.go
@@ -132,7 +132,7 @@ func setField(p *checkpb.Policy, name string, value any) {
 }
 
 func bytesSetter(name string) setterFn {
-	return func(p *checkpb.Policy, value string, t *testing.T) bool {
+	return func(p *checkpb.Policy, value string, _ *testing.T) bool {
 		v, err := hex.DecodeString(value)
 		if err != nil {
 			return true
@@ -143,14 +143,14 @@ func bytesSetter(name string) setterFn {
 }
 
 func stringSetter(name string) setterFn {
-	return func(p *checkpb.Policy, value string, t *testing.T) bool {
+	return func(p *checkpb.Policy, value string, _ *testing.T) bool {
 		setField(p, name, value)
 		return false
 	}
 }
 
 func boolSetter(name string) setterFn {
-	return func(p *checkpb.Policy, value string, t *testing.T) bool {
+	return func(p *checkpb.Policy, value string, _ *testing.T) bool {
 		switch value {
 		case "true":
 			setField(p, name, true)
@@ -165,7 +165,7 @@ func boolSetter(name string) setterFn {
 }
 
 func uint64setter(name string) setterFn {
-	return func(p *checkpb.Policy, value string, t *testing.T) bool {
+	return func(p *checkpb.Policy, value string, _ *testing.T) bool {
 		u, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
 			return true
@@ -176,7 +176,7 @@ func uint64setter(name string) setterFn {
 }
 
 func uint32setter(name string) setterFn {
-	return func(p *checkpb.Policy, value string, t *testing.T) bool {
+	return func(p *checkpb.Policy, value string, _ *testing.T) bool {
 		u, err := strconv.ParseUint(value, 10, 32)
 		if err != nil {
 			return true
@@ -187,7 +187,7 @@ func uint32setter(name string) setterFn {
 }
 
 func uint32valueSetter(name string) setterFn {
-	return func(p *checkpb.Policy, value string, t *testing.T) bool {
+	return func(p *checkpb.Policy, value string, _ *testing.T) bool {
 		u, err := strconv.ParseUint(value, 10, 32)
 		if err != nil {
 			return true
@@ -198,7 +198,7 @@ func uint32valueSetter(name string) setterFn {
 }
 
 func uint64valueSetter(name string) setterFn {
-	return func(p *checkpb.Policy, value string, t *testing.T) bool {
+	return func(p *checkpb.Policy, value string, _ *testing.T) bool {
 		u, err := strconv.ParseUint(value, 10, 64)
 		if err != nil {
 			return true

--- a/tools/lib/report/report_test.go
+++ b/tools/lib/report/report_test.go
@@ -53,7 +53,7 @@ func initDevice() {
 	for i := range ones32 {
 		ones32[i] = 1
 	}
-	opts := &test.DeviceOptions{Now: now}
+	opts := &test.DeviceOptions{Now: now, Product: abi.DefaultSevProduct()}
 	tcqp, err := test.TcQuoteProvider(tests, opts)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create test device: %v", err))
@@ -172,26 +172,31 @@ func TestReadAttestation(t *testing.T) {
 
 func TestTransform(t *testing.T) {
 	mu.Do(initDevice)
-	binout, err := Transform(input.attestation, "bin")
-	if err != nil {
-		t.Fatalf("Transform(_, \"bin\") = _, %v. Expect nil.", err)
-	}
-	if !bytes.Equal(binout, input.bincerts) {
-		t.Fatalf("Transform(_, \"bin\") = %v, nil. Expect %v.", binout, input.bincerts)
-	}
-	protoout, err := Transform(input.attestation, "proto")
-	if err != nil {
-		t.Fatalf("Transform(_, \"proto\") = _, %v. Expect nil.", err)
-	}
-	if !bytes.Equal(protoout, input.protocerts) {
-		t.Fatalf("Transform(_, \"proto\") = %v, nil. Expect %v.", protoout, input.protocerts)
-	}
-	textout, err := Transform(input.attestation, "textproto")
-	if err != nil {
-		t.Fatalf("Transform(_, \"textproto\") = _, %v. Expect nil.", err)
-	}
-	if !bytes.Equal(textout, input.textcerts) {
-		t.Fatalf("Transform(_, \"textproto\") = %v, nil. Expect %v.", string(textout), string(input.textcerts))
-	}
-
+	t.Run("bin", func(t *testing.T) {
+		binout, err := Transform(input.attestation, "bin")
+		if err != nil {
+			t.Fatalf("Transform(_, \"bin\") = _, %v. Expect nil.", err)
+		}
+		if !bytes.Equal(binout, input.bincerts) {
+			t.Fatalf("Transform(_, \"bin\") = %v, nil. Expect %v.", binout, input.bincerts)
+		}
+	})
+	t.Run("proto", func(t *testing.T) {
+		protoout, err := Transform(input.attestation, "proto")
+		if err != nil {
+			t.Fatalf("Transform(_, \"proto\") = _, %v. Expect nil.", err)
+		}
+		if !bytes.Equal(protoout, input.protocerts) {
+			t.Fatalf("Transform(_, \"proto\") = %v, nil. Expect %v.", protoout, input.protocerts)
+		}
+	})
+	t.Run("textproto", func(t *testing.T) {
+		textout, err := Transform(input.attestation, "textproto")
+		if err != nil {
+			t.Fatalf("Transform(_, \"textproto\") = _, %v. Expect nil.", err)
+		}
+		if !bytes.Equal(textout, input.textcerts) {
+			t.Fatalf("Transform(_, \"textproto\") = %v, nil. Expect %v.", string(textout), string(input.textcerts))
+		}
+	})
 }

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -162,7 +162,8 @@ func TestValidateSnpAttestation(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	qp0, err := test.TcQuoteProvider(test.TestCases(), &test.DeviceOptions{Now: now, Signer: sign0})
+	qp0, err := test.TcQuoteProvider(test.TestCases(),
+		&test.DeviceOptions{Now: now, Signer: sign0, Product: abi.DefaultSevProduct()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -506,7 +507,7 @@ func TestCertTableOptions(t *testing.T) {
 		PlatformInfo: &abi.SnpPlatformInfo{SMTEnabled: true},
 
 		CertTableOptions: map[string]*CertEntryOption{
-			"00000000-feee-feee-0000-000000000000": {Kind: CertEntryRequire, Validate: func(_ *spb.Attestation, blob []byte) error { return nil }},
+			"00000000-feee-feee-0000-000000000000": {Kind: CertEntryRequire, Validate: func(*spb.Attestation, []byte) error { return nil }},
 		},
 	}); err == nil || !strings.Contains(err.Error(), "required") {
 		t.Errorf("SnpAttestation(_, &Options{CertTableOptions: require feee-feee}) = %v, want error to contain %s", err, "required")
@@ -522,7 +523,7 @@ func TestCertTableOptions(t *testing.T) {
 				}
 				return nil
 			}},
-			"00000000-feee-feee-0000-000000000000": {Kind: CertEntryAllowMissing, Validate: func(_ *spb.Attestation, blob []byte) error { return errors.New("don't call me") }},
+			"00000000-feee-feee-0000-000000000000": {Kind: CertEntryAllowMissing, Validate: func(*spb.Attestation, []byte) error { return errors.New("don't call me") }},
 		},
 	}); err != nil {
 		t.Errorf("SnpAttestation(_, &Options{CertTableOptions: require c0de, allow feee-fee}) = %v, want nil", err)

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -161,7 +161,7 @@ func TestVerifyVcekCert(t *testing.T) {
 func TestSnpReportSignature(t *testing.T) {
 	tests := test.TestCases()
 	now := time.Date(2022, time.May, 3, 9, 0, 0, 0, time.UTC)
-	qp, err := test.TcQuoteProvider(tests, &test.DeviceOptions{Now: now})
+	qp, err := test.TcQuoteProvider(tests, &test.DeviceOptions{Now: now, Product: abi.DefaultSevProduct()})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -432,7 +432,7 @@ func TestOpenGetExtendedReportVerifyClose(t *testing.T) {
 	tests := test.TestCases()
 	qp, goodRoots, badRoots, kds := testclient.GetSevQuoteProvider(tests, &test.DeviceOptions{Now: time.Now()}, t)
 	type reportGetter func(sg.QuoteProvider, [64]byte) (*pb.Attestation, error)
-	reportOnly := func(d sg.QuoteProvider, input [64]byte) (*pb.Attestation, error) {
+	reportOnly := func(qp sg.QuoteProvider, input [64]byte) (*pb.Attestation, error) {
 		attestation, err := sg.GetQuoteProto(qp, input)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This is to help Issue#108.
The RawQuote interface is missing SevProduct that is present in the Attestation message, so use a new GUID entry in the certificate table to add custom information that can be forwarded to the verifier.