### PR TITLE
Only add extra product info if vcek cert missing

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -1015,6 +1015,11 @@ func ExtendPlatformCertTable(data []byte, info *ExtraPlatformInfo) ([]byte, erro
 	if err := certs.Unmarshal(data); err != nil {
 		return nil, err
 	}
+	// Don't extend the entries with unnecessary information about the platform
+	// since the VCEK certificate already contains it in an extension.
+	if _, err := certs.GetByGUIDString(VcekGUID); err == nil {
+		return data, nil
+	}
 	// A directly constructed info cannot have a marshaling error.
 	extra, err := info.Marshal()
 	if err != nil {


### PR DESCRIPTION
This extra entry doesn't need to waste bandwidth when all the required information is present in the VCEK cert.