### PR TITLE
Clean up internal deprecated interface uses

### DIFF
--- a/kds/kds.go
+++ b/kds/kds.go
@@ -539,6 +539,14 @@ type VCEKCert struct {
 	TCB         uint64
 }
 
+// VCEKCertProduct returns a VCEKCert with the product line set to productLine.
+func VCEKCertProduct(productLine string) VCEKCert {
+	return VCEKCert{
+		Product:     productLine, // TODO(Issue#114): Remove
+		ProductLine: productLine,
+	}
+}
+
 // VLEKCert represents the attestation report components represented in a KDS VLEK certificate
 // request URL.
 type VLEKCert struct {
@@ -787,23 +795,23 @@ func ProductName(product *pb.SevProduct) string {
 //
 // Deprecated: Use ParseProductLine
 func ParseProduct(productLine string) (pb.SevProduct_SevProductName, error) {
-	switch productLine {
-	case "Milan":
-		return pb.SevProduct_SEV_PRODUCT_MILAN, nil
-	case "Genoa":
-		return pb.SevProduct_SEV_PRODUCT_GENOA, nil
-	default:
-		return pb.SevProduct_SEV_PRODUCT_UNKNOWN, fmt.Errorf("unknown AMD SEV product: %q", productLine)
+	p, err := ParseProductLine(productLine)
+	if err != nil {
+		return pb.SevProduct_SEV_PRODUCT_UNKNOWN, nil
 	}
+	return p.Name, nil
 }
 
 // ParseProductLine returns the SevProductName for a product name without the stepping suffix.
 func ParseProductLine(productLine string) (*pb.SevProduct, error) {
-	name, err := ParseProduct(productLine)
-	if err != nil {
-		return nil, err
+	switch productLine {
+	case "Milan":
+		return &pb.SevProduct{Name: pb.SevProduct_SEV_PRODUCT_MILAN}, nil
+	case "Genoa":
+		return &pb.SevProduct{Name: pb.SevProduct_SEV_PRODUCT_GENOA}, nil
+	default:
+		return nil, fmt.Errorf("unknown AMD SEV product: %q", productLine)
 	}
-	return &pb.SevProduct{Name: name}, nil
 }
 
 // ParseProductName returns the KDS project input value, and the model, stepping numbers represented

--- a/kds/kds_test.go
+++ b/kds/kds_test.go
@@ -140,7 +140,12 @@ func TestParseVCEKCertURL(t *testing.T) {
 		{
 			name: "happy path",
 			url:  VCEKCertURL("Milan", hwid, TCBVersion(0)),
-			want: VCEKCert{Product: "Milan", ProductLine: "Milan", HWID: hwid, TCB: 0},
+			want: func() VCEKCert {
+				c := VCEKCertProduct("Milan")
+				c.HWID = hwid
+				c.TCB = 0
+				return c
+			}(),
 		},
 		{
 			name:    "bad query format",

--- a/proto/check.proto
+++ b/proto/check.proto
@@ -58,7 +58,8 @@ message Policy {
 // RootOfTrust represents configuration for which hardware root of trust
 // certificates to use for verifying attestation report signatures.
 message RootOfTrust {
-  // The expected AMD product the attestation was collected from. Default "Milan".
+  // The expected AMD product the attestation was collected from. Default
+  // "Milan".
   string product = 1 [deprecated = true];
 
   // Paths to CA bundles for the AMD product.

--- a/proto/check/check.pb.go
+++ b/proto/check/check.pb.go
@@ -282,7 +282,8 @@ type RootOfTrust struct {
 	sizeCache     protoimpl.SizeCache
 	unknownFields protoimpl.UnknownFields
 
-	// The expected AMD product the attestation was collected from. Default "Milan".
+	// The expected AMD product the attestation was collected from. Default
+	// "Milan".
 	//
 	// Deprecated: Marked as deprecated in check.proto.
 	Product string `protobuf:"bytes,1,opt,name=product,proto3" json:"product,omitempty"`

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -501,12 +501,10 @@ func decodeCerts(chain *spb.CertificateChain, key abi.ReportSigner, options *Opt
 		return nil, nil, err
 	}
 	if len(roots) == 0 {
-		root := &trust.AMDRootCerts{
-			Product: productLine,
-			// Require that the root matches embedded root certs.
-			AskSev: trust.DefaultRootCerts[productLine].AskSev,
-			ArkSev: trust.DefaultRootCerts[productLine].ArkSev,
-		}
+		root := trust.AMDRootCertsProduct(productLine)
+		// Require that the root matches embedded root certs.
+		root.AskSev = trust.DefaultRootCerts[productLine].AskSev
+		root.ArkSev = trust.DefaultRootCerts[productLine].ArkSev
 		if err := root.Decode(chain.GetAskCert(), chain.GetArkCert()); err != nil {
 			return nil, nil, err
 		}


### PR DESCRIPTION
Packages and tests should not use deprecated fields and functions, so fix up some newly deprecated items.