### PR TITLE
Skip negative cpuid test when on SNP hardware

### DIFF
--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -572,6 +572,10 @@ func TestGetQuoteProviderVerify(t *testing.T) {
 }
 
 func TestGetQuoteProviderVerifyProductNameSteppingMismatch(t *testing.T) {
+	if !sg.UseDefaultSevGuest() {
+		t.Skip("Cannot override true cpuid in hardware for negative testing")
+		return
+	}
 	trust.ClearProductCertCache()
 	tests := test.TestCases()
 	signerMilan0, err := test.DefaultTestOnlyCertChain("Milan-B0", time.Now())


### PR DESCRIPTION
The hardware quote provider doesn't allow for cpuid and certificate override, so skip this test when not simulating.