### PR TITLE
Add some nil checking to validate.go

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -612,10 +612,21 @@ func validateKeys(report *spb.Report, options *Options) error {
 }
 
 func validateKeyKind(report *spb.Attestation) (*x509.Certificate, error) {
+	if report == nil {
+		return nil, fmt.Errorf("attestation cannot be nil")
+	}
+	if report.GetReport() == nil {
+		return nil, fmt.Errorf("attestation report cannot be nil")
+	}
+	if report.GetCertificateChain() == nil {
+		return nil, fmt.Errorf("attestation certificate chain cannot be nil")
+	}
+
 	info, err := abi.ParseSignerInfo(report.GetReport().GetSignerInfo())
 	if err != nil {
 		return nil, err
 	}
+
 	switch info.SigningKey {
 	case abi.VcekReportSigner:
 		if len(report.GetCertificateChain().VcekCert) != 0 {


### PR DESCRIPTION
Calling validate.SnpAttestation with an incomplete attesstation report will lead to nil dereferences instead of meaningful errors without this.