### PR TITLE
Reword certTableOptions log.Warning message

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -655,7 +655,7 @@ func certTableOptions(attestation *spb.Attestation, options map[string]*CertEntr
 			if opt.Kind == CertEntryRequire {
 				return err
 			}
-			logger.Warningf("Missing cert entry for %s", key)
+			logger.Warningf("Missing or invalid cert entry for %s", key)
 		}
 	}
 	return nil


### PR DESCRIPTION
Found this while investigating a bug that was caused by this golden cert being invalid.

This warning message is printed even when there is a cert, but it is invalid. Reworded it to make it clearer that the cert with the corresponding key is either missing or invalid.

I also tried "No valid cert..." but I feel like that doesn't capture the case when there is literally no cert whatsoever. 