### PR TITLE
Remove ASK/ARK warnings

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -875,13 +875,6 @@ func (c *CertTable) Proto() *pb.CertificateChain {
 	if len(result.VcekCert) == 0 && len(result.VlekCert) == 0 {
 		logger.Warning("Warning: Neither VCEK nor VLEK certificate found in data pages")
 	}
-
-	if len(result.AskCert) == 0 {
-		logger.Warningf("ASK certificate not found in data pages")
-	}
-	if len(result.ArkCert) == 0 {
-		logger.Warningf("ARK certificate not found in data pages")
-	}
 	return result
 }
 


### PR DESCRIPTION
The ASK and ARK ought to be embedded in the Verifier and are not necessary for the host to forward. AWS EC2 does not provide the ASVK or ARK, so drop the nuisance warnings.