### PR TITLE
tools/show: set correct inform

### DIFF
--- a/tools/show/main.go
+++ b/tools/show/main.go
@@ -25,7 +25,7 @@ import (
 
 var (
 	infile = flag.String("in", "-", "Path to attestation file, or - for stdin.")
-	inform = flag.String("inform", "in", "Format of the attestation file. "+
+	inform = flag.String("inform", "bin", "Format of the attestation file. "+
 		"One of bin, proto, textproto")
 	outfile = flag.String("out", "-", "Path to output file, or - for stdout.")
 	outform = flag.String("outform", "textproto", "Format of the output file. "+


### PR DESCRIPTION
There was a typo in the `show` tool that specified an invalid `inform`. This fixes it by setting it to the (presumably wanted) `bin` format.