### PR TITLE
Resolve CI runner failures for ubuntu24.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,15 @@ on:
   push:
     tags:
       - v*
-    branches:
-      - main
+    branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.19.x, 1.20.x]
+        go-version: [1.21.x, 1.22.x]
         os: [macos-latest, ubuntu-latest]
 
     name: Build/Test (${{ matrix.os}}, Go ${{ matrix.go-version }})
@@ -61,7 +61,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest]
 
     name: Lint ${{ matrix.dir }} (${{ matrix.os }}, Go ${{ matrix.go-version }})
@@ -93,7 +93,7 @@ jobs:
   lintc:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.21.x]
         os: [ubuntu-latest]
 
     name: Lint CGO (${{ matrix.os}}, Go ${{ matrix.go-version }})


### PR DESCRIPTION
Older Golang versions are not supported on the latest ubuntu runner image.

https://github.com/actions/runner-images/issues/10636