### PR TITLE
Add Genoa's product name without stepping

### DIFF
--- a/kds/kds.go
+++ b/kds/kds.go
@@ -96,6 +96,7 @@ var (
 	steppingDecoder = map[string]*pb.SevProduct{
 		"Milan-B0": {Name: pb.SevProduct_SEV_PRODUCT_MILAN, MachineStepping: uint0},
 		"Milan-B1": {Name: pb.SevProduct_SEV_PRODUCT_MILAN, MachineStepping: uint1},
+		"Genoa":    {Name: pb.SevProduct_SEV_PRODUCT_GENOA, MachineStepping: uint0},
 		"Genoa-B0": {Name: pb.SevProduct_SEV_PRODUCT_GENOA, MachineStepping: uint0},
 		"Genoa-B1": {Name: pb.SevProduct_SEV_PRODUCT_GENOA, MachineStepping: uint1},
 		"Genoa-B2": {Name: pb.SevProduct_SEV_PRODUCT_GENOA, MachineStepping: uint2},


### PR DESCRIPTION
AMD's KDS generates VCEK for Genoa without stepping information in X509v3 extensions. See below for example:

% openssl x509 -in vcek.pem -text -noout
...
...
        X509v3 extensions:
            1.3.6.1.4.1.3704.1.1:
                ...
            1.3.6.1.4.1.3704.1.2:
                ..Genoa
...
...

As such, someone performs verification of the attestation report with such VCEK, go-sev-guest reports an error as "Genoa" isn't in its database. Add "Genoa" to the database to workaround this problem.