### PR TITLE
GetCrlAndCheckRoot: always verify CRL

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -118,7 +118,7 @@ func validateAmdLocation(name pkix.Name, role string) error {
 	if err := checkSingletonList(name.Organization, "organization", "organizations", "Advanced Micro Devices"); err != nil {
 		return err
 	}
-	return checkSingletonList(name.OrganizationalUnit, "organizational unit", "organizational uints", "Engineering")
+	return checkSingletonList(name.OrganizationalUnit, "organizational unit", "organizational units", "Engineering")
 }
 
 func validateRootX509(productLine string, x *x509.Certificate, version int, role, cn string) error {

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -301,6 +301,9 @@ func GetCrlAndCheckRoot(r *trust.AMDRootCerts, opts *Options) (*x509.RevocationL
 		getter = trust.DefaultHTTPSGetter()
 	}
 	if r.CRL != nil && opts.Now.Before(r.CRL.NextUpdate) {
+		if err := verifyCRL(r); err != nil {
+			return nil, err
+		}
 		return r.CRL, nil
 	}
 	var errs error


### PR DESCRIPTION
Before, when an CRL was set in the TrustedRoot, it's CRL was not checked.
Since the CRL is only checked on retrieval, setting an CRL disabled the CRL
verification. So either the user needs to check the CRL manually before
setting it or let the library request the CRL again. The second options
breaks attestation when being strict about CRL verification and the KDS
is not available.

Change this to always verify the CRL when calling SnpAttestation.