### PR TITLE
verify: use context for resource fetching

### DIFF
--- a/verify/trust/trust.go
+++ b/verify/trust/trust.go
@@ -130,6 +130,20 @@ type HTTPSGetter interface {
 	Get(url string) ([]byte, error)
 }
 
+// ContextHTTPSGetter is an HTTPSGetter that accepts a context.Context.
+type ContextHTTPSGetter interface {
+	GetContext(ctx context.Context, url string) ([]byte, error)
+}
+
+// GetWith gets a resource from a url using a getter.
+// If the getter implements ContextHTTPSGetter, the context will be forwarded to the getter.
+func GetWith(ctx context.Context, getter HTTPSGetter, url string) ([]byte, error) {
+	if contextGetter, ok := getter.(ContextHTTPSGetter); ok {
+		return contextGetter.GetContext(ctx, url)
+	}
+	return getter.Get(url)
+}
+
 // AttestationRecreationErr represents a problem with fetching or interpreting associated
 // certificates for a given attestation report. This is typically due to network unreliability.
 type AttestationRecreationErr struct {
@@ -145,7 +159,15 @@ type SimpleHTTPSGetter struct{}
 
 // Get uses http.Get to return the HTTPS response body as a byte array.
 func (n *SimpleHTTPSGetter) Get(url string) ([]byte, error) {
-	resp, err := http.Get(url)
+	return n.GetContext(context.Background(), url)
+}
+
+func (n *SimpleHTTPSGetter) GetContext(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	} else if resp.StatusCode >= 300 {
@@ -160,6 +182,11 @@ func (n *SimpleHTTPSGetter) Get(url string) ([]byte, error) {
 	return body, nil
 }
 
+var (
+	_ = HTTPSGetter(&SimpleHTTPSGetter{})
+	_ = ContextHTTPSGetter(&SimpleHTTPSGetter{})
+)
+
 // RetryHTTPSGetter is a meta-HTTPS getter that will retry on failure a given number of times.
 type RetryHTTPSGetter struct {
 	// Timeout is how long to retry before failure.
@@ -172,11 +199,15 @@ type RetryHTTPSGetter struct {
 
 // Get fetches the body of the URL, retrying a given amount of times on failure.
 func (n *RetryHTTPSGetter) Get(url string) ([]byte, error) {
+	return n.GetContext(context.Background(), url)
+}
+
+func (n *RetryHTTPSGetter) GetContext(ctx context.Context, url string) ([]byte, error) {
 	delay := initialDelay
-	ctx, cancel := context.WithTimeout(context.Background(), n.Timeout)
+	ctx, cancel := context.WithTimeout(ctx, n.Timeout)
 	var returnedError error
 	for {
-		body, err := n.Getter.Get(url)
+		body, err := GetWith(ctx, n.Getter, url)
 		if err == nil {
 			cancel()
 			return body, nil
@@ -194,6 +225,11 @@ func (n *RetryHTTPSGetter) Get(url string) ([]byte, error) {
 		}
 	}
 }
+
+var (
+	_ = HTTPSGetter(&RetryHTTPSGetter{})
+	_ = ContextHTTPSGetter(&RetryHTTPSGetter{})
+)
 
 // DefaultHTTPSGetter returns the library's default getter implementation. It will
 // retry slowly due to the AMD KDS's rate limiting.
@@ -311,6 +347,10 @@ func ClearProductCertCache() {
 // GetProductChain returns the ASK and ARK certificates of the given product line, either from getter
 // or from a cache of the results from the last successful call.
 func GetProductChain(productLine string, s abi.ReportSigner, getter HTTPSGetter) (*ProductCerts, error) {
+	return GetProductChainContext(context.Background(), productLine, s, getter)
+}
+
+func GetProductChainContext(ctx context.Context, productLine string, s abi.ReportSigner, getter HTTPSGetter) (*ProductCerts, error) {
 	if productLineCertCache == nil {
 		prodCacheMu.Lock()
 		productLineCertCache = make(map[string]*ProductCerts)
@@ -318,7 +358,7 @@ func GetProductChain(productLine string, s abi.ReportSigner, getter HTTPSGetter)
 	}
 	result, ok := productLineCertCache[productLine]
 	if !ok {
-		askark, err := getter.Get(kds.ProductCertChainURL(s, productLine))
+		askark, err := GetWith(ctx, getter, kds.ProductCertChainURL(s, productLine))
 		if err != nil {
 			return nil, &AttestationRecreationErr{
 				Msg: fmt.Sprintf("could not download ASK and ARK certificates: %v", err),

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -16,6 +16,7 @@
 package verify
 
 import (
+	"context"
 	"crypto/ecdsa"
 	"crypto/rsa"
 	"crypto/x509"
@@ -294,6 +295,10 @@ type CRLUnavailableErr struct {
 // GetCrlAndCheckRoot downloads the given cert's CRL from one of the distribution points and
 // verifies that the CRL is valid and doesn't revoke an intermediate key.
 func GetCrlAndCheckRoot(r *trust.AMDRootCerts, opts *Options) (*x509.RevocationList, error) {
+	return GetCrlAndCheckRootContext(context.Background(), r, opts)
+}
+
+func GetCrlAndCheckRootContext(ctx context.Context, r *trust.AMDRootCerts, opts *Options) (*x509.RevocationList, error) {
 	r.Mu.Lock()
 	defer r.Mu.Unlock()
 	getter := opts.Getter
@@ -308,7 +313,7 @@ func GetCrlAndCheckRoot(r *trust.AMDRootCerts, opts *Options) (*x509.RevocationL
 	}
 	var errs error
 	for _, url := range r.ProductCerts.Ask.CRLDistributionPoints {
-		bytes, err := getter.Get(url)
+		bytes, err := trust.GetWith(ctx, getter, url)
 		if err != nil {
 			errs = multierr.Append(errs, err)
 			continue
@@ -662,6 +667,10 @@ func updateProductExpectation(product **spb.SevProduct, reportProduct *spb.SevPr
 // SnpAttestation verifies the protobuf representation of an attestation report's signature based
 // on the report's SignatureAlgo, provided the certificate chain is valid.
 func SnpAttestation(attestation *spb.Attestation, options *Options) error {
+	return SnpAttestationContext(context.Background(), attestation, options)
+}
+
+func SnpAttestationContext(ctx context.Context, attestation *spb.Attestation, options *Options) error {
 	if options == nil {
 		return fmt.Errorf("options cannot be nil")
 	}
@@ -670,7 +679,7 @@ func SnpAttestation(attestation *spb.Attestation, options *Options) error {
 	}
 	// Make sure we have the whole certificate chain, or at least the product
 	// info.
-	if err := fillInAttestation(attestation, options); err != nil {
+	if err := fillInAttestation(ctx, attestation, options); err != nil {
 		return err
 	}
 
@@ -786,7 +795,7 @@ func cpuidWorkaround(attestation *spb.Attestation, options *Options) (string, fu
 
 // fillInAttestation uses AMD's KDS to populate any empty certificate field in the attestation's
 // certificate chain.
-func fillInAttestation(attestation *spb.Attestation, options *Options) error {
+func fillInAttestation(ctx context.Context, attestation *spb.Attestation, options *Options) error {
 	if options.DisableCertFetching {
 		return nil
 	}
@@ -826,7 +835,7 @@ func fillInAttestation(attestation *spb.Attestation, options *Options) error {
 	case abi.VcekReportSigner:
 		if len(chain.GetVcekCert()) == 0 {
 			vcekURL := kds.VCEKCertURL(productLine, report.GetChipId(), kds.TCBVersion(report.GetReportedTcb()))
-			vcek, err := getter.Get(vcekURL)
+			vcek, err := trust.GetWith(ctx, getter, vcekURL)
 			if err != nil {
 				return &trust.AttestationRecreationErr{
 					Msg: fmt.Sprintf("could not download VCEK certificate: %v", err),
@@ -854,11 +863,15 @@ func fillInAttestation(attestation *spb.Attestation, options *Options) error {
 // chain for the VCEK that supposedly signed the given report, and returns the Attestation
 // representation of their combination. If getter is nil, uses Golang's http.Get.
 func GetAttestationFromReport(report *spb.Report, options *Options) (*spb.Attestation, error) {
+	return GetAttestationFromReportContext(context.Background(), report, options)
+}
+
+func GetAttestationFromReportContext(ctx context.Context, report *spb.Report, options *Options) (*spb.Attestation, error) {
 	result := &spb.Attestation{
 		Report:           report,
 		CertificateChain: &spb.CertificateChain{Extras: map[string][]byte{}},
 	}
-	if err := fillInAttestation(result, options); err != nil {
+	if err := fillInAttestation(ctx, result, options); err != nil {
 		return nil, err
 	}
 	// Attempt to fill in the product field of the attestation. Don't error at this

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -16,6 +16,7 @@ package verify
 
 import (
 	"bytes"
+	"context"
 	"crypto/rsa"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -844,7 +845,7 @@ func TestV3KDSProduct(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			report, _ := abi.ReportToProto(tc.Output[:])
 			a := &spb.Attestation{Report: report}
-			if err := fillInAttestation(a, options); err != nil {
+			if err := fillInAttestation(context.Background(), a, options); err != nil {
 				t.Fatalf("fillInAttestation(%v, %v) = %v, want nil", a, options, err)
 			}
 			var want []byte


### PR DESCRIPTION
### Problem statement

I'm calling the `verify` package from an RPC handler, where timeout and cancellation are controlled by a `context.Context` object from the environment. I'd like to forward this context to the `trust.HTTPSGetter`, in particular to make it abort in case of a context cancellation. This would be particularly useful during KDS outages.

Unrelated, but also relevant: the context could be used to pass additional information to the getter.

### Alternatives

I could make a custom implementation of `trust.HTTPSGetter` that embeds a context object. However, this is discouraged by https://pkg.go.dev/context itself and also makes it harder to share the `verify.Options` between calls. 

### Notes to reviewer

I'm opening this early draft to get feedback on the approach. In this branch, I tried to keep all existing APIs intact both in signature and semantics. The downside is that many functions now have a `*Context()` companion that does not exactly roll off the tongue and feels a little bit duplicated. Open to suggestions for a different approach.

As long as we're still discussing strategy, I'm holding back extensive docs and tests.
