### PR TITLE
abi.SnpPolicy: add missing fields

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -66,12 +66,16 @@ const (
 	// SignatureSize is the field size of SIGNATURE in an SEV-SNP attestation report.
 	SignatureSize = 512
 
-	policyOffset          = 0x08
-	policySMTBit          = 16
-	policyReserved1bit    = 17
-	policyMigrateMABit    = 18
-	policyDebugBit        = 19
-	policySingleSocketBit = 20
+	policyOffset                  = 0x08
+	policySMTBit                  = 16
+	policyReserved1bit            = 17
+	policyMigrateMABit            = 18
+	policyDebugBit                = 19
+	policySingleSocketBit         = 20
+	policyCLXAllowBit             = 21
+	policyMemAES256XTSBit         = 22
+	policyRAPLDisBit              = 23
+	policyCipherTextHidingDRAMBit = 24
 
 	maxPlatformInfoBit = 5
 
@@ -216,6 +220,15 @@ type SnpPolicy struct {
 	Debug bool
 	// SingleSocket is true if the guest may only be active on a single socket.
 	SingleSocket bool
+	// CXLAllowed is true if CLX can be populated with devices or memory.
+	CXLAllowed bool
+	// MemAES256XTS is true if AES-256-XTS is required for memory encryption.
+	// If false, either AES-128-XEX or AES-256-XTS is allowed.
+	MemAES256XTS bool
+	// RAPLDis is true if Running Average Power Limit (RAPL) must be disabled.
+	RAPLDis bool
+	// CipherTextHidingDRAM is true if ciphertext hiding for the DRAM must be enabled.
+	CipherTextHidingDRAM bool
 }
 
 // ParseSnpPolicy interprets the SEV SNP API's guest policy bitmask into an SnpPolicy struct type.
@@ -224,7 +237,7 @@ func ParseSnpPolicy(guestPolicy uint64) (SnpPolicy, error) {
 	if guestPolicy&uint64(1<<policyReserved1bit) == 0 {
 		return result, fmt.Errorf("policy[%d] is reserved, must be 1, got 0", policyReserved1bit)
 	}
-	if err := mbz64(guestPolicy, "policy", 63, 21); err != nil {
+	if err := mbz64(guestPolicy, "policy", 63, 25); err != nil {
 		return result, err
 	}
 	result.ABIMinor = uint8(guestPolicy & 0xff)
@@ -233,6 +246,10 @@ func ParseSnpPolicy(guestPolicy uint64) (SnpPolicy, error) {
 	result.MigrateMA = (guestPolicy & (1 << policyMigrateMABit)) != 0
 	result.Debug = (guestPolicy & (1 << policyDebugBit)) != 0
 	result.SingleSocket = (guestPolicy & (1 << policySingleSocketBit)) != 0
+	result.CXLAllowed = (guestPolicy & (1 << policyCLXAllowBit)) != 0
+	result.MemAES256XTS = (guestPolicy & (1 << policyMemAES256XTSBit)) != 0
+	result.RAPLDis = (guestPolicy & (1 << policyRAPLDisBit)) != 0
+	result.CipherTextHidingDRAM = (guestPolicy & (1 << policyCipherTextHidingDRAMBit)) != 0
 	return result, nil
 }
 
@@ -250,6 +267,18 @@ func SnpPolicyToBytes(policy SnpPolicy) uint64 {
 	}
 	if policy.SingleSocket {
 		result |= uint64(1 << policySingleSocketBit)
+	}
+	if policy.CXLAllowed {
+		result |= uint64(1 << policyCLXAllowBit)
+	}
+	if policy.MemAES256XTS {
+		result |= uint64(1 << policyMemAES256XTSBit)
+	}
+	if policy.RAPLDis {
+		result |= uint64(1 << policyRAPLDisBit)
+	}
+	if policy.CipherTextHidingDRAM {
+		result |= uint64(1 << policyCipherTextHidingDRAMBit)
 	}
 	return result
 }

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -156,10 +156,10 @@ func TestReportMbz(t *testing.T) {
 			wantErr:     "policy[17] is reserved, must be 1, got 0",
 		},
 		{
-			name:        "Guest policy bit 21",
-			changeIndex: policyOffset + 2, // Bits 16-23
-			changeValue: 0x22,             // Set bits 17, 21
-			wantErr:     "malformed guest policy: mbz range policy[0x15:0x3f] not all zero: 220000",
+			name:        "Guest policy bit 25",
+			changeIndex: policyOffset + 3, // Bits 24-31
+			changeValue: 0x80,             // Set bit 25
+			wantErr:     "malformed guest policy: mbz range policy[0x19:0x3f] not all zero",
 		},
 	}
 	reportProto := &spb.Report{}
@@ -204,12 +204,16 @@ func TestSnpPolicySection(t *testing.T) {
 	rand.Read(entropy)
 	for tc := 0; tc < entropySize/3; tc++ {
 		policy := SnpPolicy{
-			ABIMinor:     entropy[tc*3],
-			ABIMajor:     entropy[tc*3+1],
-			SMT:          (entropy[tc*3+2] & 1) != 0,
-			MigrateMA:    (entropy[tc*3+2] & 2) != 0,
-			Debug:        (entropy[tc*3+2] & 4) != 0,
-			SingleSocket: (entropy[tc*3+2] & 8) != 0,
+			ABIMinor:             entropy[tc*3],
+			ABIMajor:             entropy[tc*3+1],
+			SMT:                  (entropy[tc*3+2] & 1) != 0,
+			MigrateMA:            (entropy[tc*3+2] & 2) != 0,
+			Debug:                (entropy[tc*3+2] & 4) != 0,
+			SingleSocket:         (entropy[tc*3+2] & 8) != 0,
+			CXLAllowed:           (entropy[tc*3+2] & 16) != 0,
+			MemAES256XTS:         (entropy[tc*3+2] & 32) != 0,
+			RAPLDis:              (entropy[tc*3+2] & 64) != 0,
+			CipherTextHidingDRAM: (entropy[tc*3+2] & 128) != 0,
 		}
 
 		got, err := ParseSnpPolicy(SnpPolicyToBytes(policy))

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -292,6 +292,19 @@ func validatePolicy(reportPolicy uint64, required abi.SnpPolicy) error {
 	if required.SingleSocket && !policy.SingleSocket {
 		return errors.New("required single socket restriction not present")
 	}
+	if required.CXLAllowed && !policy.CXLAllowed {
+		return errors.New("found unauthorized CXL capability")
+	}
+	if required.MemAES256XTS && !policy.MemAES256XTS {
+		return errors.New("found unauthorized memory encryption mode")
+	}
+	if required.RAPLDis && !policy.RAPLDis {
+		return errors.New("found unauthorized RAPL capability")
+	}
+	if required.CipherTextHidingDRAM && !policy.CipherTextHidingDRAM {
+		return errors.New("chiphertext hiding in DRAM isn't enforced")
+	}
+
 	return nil
 }
 

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -532,11 +532,23 @@ func validatePlatformInfo(platformInfo uint64, required *abi.SnpPlatformInfo) er
 	if err != nil {
 		return fmt.Errorf("could not parse SNP platform info %x: %v", platformInfo, err)
 	}
+	if reportInfo.SMTEnabled && !required.SMTEnabled {
+		return errors.New("unauthorized platform feature SMT enabled")
+	}
 	if reportInfo.TSMEEnabled && !required.TSMEEnabled {
 		return errors.New("unauthorized platform feature TSME enabled")
 	}
-	if reportInfo.SMTEnabled && !required.SMTEnabled {
-		return errors.New("unauthorized platform feature SMT enabled")
+	if reportInfo.ECCEnabled && !required.ECCEnabled {
+		return errors.New("unauthorized platform feature ECC enabled")
+	}
+	if reportInfo.RAPLDisabled && !required.RAPLDisabled {
+		return errors.New("platform feature RAPL isn't enabled")
+	}
+	if reportInfo.CiphertextHidingDRAMEnabled && !required.CiphertextHidingDRAMEnabled {
+		return errors.New("chiphertext hiding in DRAM not enforced")
+	}
+	if reportInfo.AliasCheckComplete && !required.AliasCheckComplete {
+		return errors.New("memory alias check hasn't been completed")
 	}
 	return nil
 }


### PR DESCRIPTION
Follow up to https://github.com/google/go-sev-guest/pull/148, adding the nearly similar missing field to **SnpPolicy** that have previously been missing on `PlatformInfo`.