### PR TITLE
validate: fix platform validation

### DIFF
--- a/validate/validate.go
+++ b/validate/validate.go
@@ -292,7 +292,7 @@ func validatePolicy(reportPolicy uint64, required abi.SnpPolicy) error {
 	if required.SingleSocket && !policy.SingleSocket {
 		return errors.New("required single socket restriction not present")
 	}
-	if required.CXLAllowed && !policy.CXLAllowed {
+	if !required.CXLAllowed && policy.CXLAllowed {
 		return errors.New("found unauthorized CXL capability")
 	}
 	if required.MemAES256XTS && !policy.MemAES256XTS {
@@ -538,17 +538,17 @@ func validatePlatformInfo(platformInfo uint64, required *abi.SnpPlatformInfo) er
 	if reportInfo.TSMEEnabled && !required.TSMEEnabled {
 		return errors.New("unauthorized platform feature TSME enabled")
 	}
-	if reportInfo.ECCEnabled && !required.ECCEnabled {
-		return errors.New("unauthorized platform feature ECC enabled")
+	if !reportInfo.ECCEnabled && required.ECCEnabled {
+		return errors.New("required platform feature ECC not enabled")
 	}
-	if reportInfo.RAPLDisabled && !required.RAPLDisabled {
-		return errors.New("platform feature RAPL isn't enabled")
+	if !reportInfo.RAPLDisabled && required.RAPLDisabled {
+		return errors.New("unauthorized platform feature RAPL enabled")
 	}
-	if reportInfo.CiphertextHidingDRAMEnabled && !required.CiphertextHidingDRAMEnabled {
-		return errors.New("chiphertext hiding in DRAM not enforced")
+	if !reportInfo.CiphertextHidingDRAMEnabled && required.CiphertextHidingDRAMEnabled {
+		return errors.New("required ciphertext hiding in DRAM not enforced")
 	}
-	if reportInfo.AliasCheckComplete && !required.AliasCheckComplete {
-		return errors.New("memory alias check hasn't been completed")
+	if !reportInfo.AliasCheckComplete && required.AliasCheckComplete {
+		return errors.New("required memory alias check hasn't been completed")
 	}
 	return nil
 }


### PR DESCRIPTION
Revisited the validation of platform info and policy and found some mistakes in my earlier PR.

I think the description in the readme was/is outdated, too: https://github.com/google/go-sev-guest/blob/main/README.md?plain=1#L158-L166
It is hard to describe the current strategy to a user. As I understand it, the current approach is to check whether the validation options require the more secure value of a field to be set, and accept the both values otherwise. However, for some fields, it is not clear (to me) what the "more secure" value is (TSMEEnabled for example), and that the fields naming switches between XEnabled/XDisabled doesn't make it easier. If we want to keep it this way, we could add a  comment on each field of the struct which is the more secure configuration.

I also thought the validation options for platform info might be better implemented as a struct fields of type *bool, to disable validation of certain values via nil, and otherwise enforce the exact value.

For the guest policy, I'm not sure whether we should be checking for equality instead, as the SP already implements the check in a way that also allows the more secure option. For example for SingleSocket, if the guest policy does not require it, the SP will still allow it to be enabled when checking the policy on guest launch. So a user who doesn't care about whether it is enabled or not could just use a policy with SingleSocket=True, and could check for equality of that value in the validation. The current approach accepts both guest that don't care about the value of SingleSocket as well as those that strictly enforce SingleSocket=False.