### PR TITLE
verify: check that received CRLs are within their validity windows

### DIFF
--- a/verify/verify.go
+++ b/verify/verify.go
@@ -272,8 +272,12 @@ func GetCrlAndCheckRootContext(ctx context.Context, r *trust.AMDRootCerts, opts 
 	if getter == nil {
 		getter = trust.DefaultHTTPSGetter()
 	}
-	if r.CRL != nil && opts.Now.Before(r.CRL.NextUpdate) {
-		if err := verifyCRL(r); err != nil {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if r.CRL != nil && now.Before(r.CRL.NextUpdate) {
+		if err := verifyCRL(r, now); err != nil {
 			return nil, err
 		}
 		return r.CRL, nil
@@ -291,7 +295,7 @@ func GetCrlAndCheckRootContext(ctx context.Context, r *trust.AMDRootCerts, opts 
 			continue
 		}
 		r.CRL = crl
-		if err := verifyCRL(r); err != nil {
+		if err := verifyCRL(r, now); err != nil {
 			return nil, err
 		}
 		return r.CRL, nil
@@ -299,9 +303,10 @@ func GetCrlAndCheckRootContext(ctx context.Context, r *trust.AMDRootCerts, opts 
 	return nil, CRLUnavailableErr{multierr.Append(errs, errors.New("could not fetch product CRL"))}
 }
 
-// verifyCRL checks that the VCEK CRL is signed by the ARK. Must be called after r.CRL is set and while
+// verifyCRL checks that the VCEK CRL is signed by the ARK and that it is currently within its
+// validity window (thisUpdate <= now < nextUpdate). Must be called after r.CRL is set and while
 // r.Mu is held.
-func verifyCRL(r *trust.AMDRootCerts) error {
+func verifyCRL(r *trust.AMDRootCerts, now time.Time) error {
 	if r.CRL == nil {
 		return errors.New("internal error: CRL not set")
 	}
@@ -313,6 +318,12 @@ func verifyCRL(r *trust.AMDRootCerts) error {
 	}
 	if err := r.CRL.CheckSignatureFrom(r.ProductCerts.Ark); err != nil {
 		return fmt.Errorf("CRL is not signed by ARK: %v", err)
+	}
+	if now.Before(r.CRL.ThisUpdate) {
+		return fmt.Errorf("CRL is not yet valid: thisUpdate is %v, now is %v", r.CRL.ThisUpdate, now)
+	}
+	if !now.Before(r.CRL.NextUpdate) {
+		return fmt.Errorf("CRL is expired: nextUpdate is %v, now is %v", r.CRL.NextUpdate, now)
 	}
 	for _, bad := range r.CRL.RevokedCertificates {
 		if r.ProductCerts.Ask.SerialNumber.Cmp(bad.SerialNumber) == 0 {

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -398,6 +398,8 @@ func TestCRLRootValidity(t *testing.T) {
 	afterCreation := now.Add(1 * time.Minute)
 	template := &x509.RevocationList{
 		SignatureAlgorithm: x509.SHA384WithRSAPSS,
+		ThisUpdate:         now,
+		NextUpdate:         now.Add(24 * time.Hour),
 		RevokedCertificates: []pkix.RevokedCertificate{
 			// The default fake VCEK serial number is 0.
 			{SerialNumber: big.NewInt(0), RevocationTime: afterCreation},
@@ -430,7 +432,7 @@ func TestCRLRootValidity(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			wantErr := "CRL is not signed by ARK"
-			if err := vcekNotRevoked(root, signer2.Vcek, &Options{Getter: g2}); !test.Match(err, wantErr) {
+			if err := vcekNotRevoked(root, signer2.Vcek, &Options{Getter: g2, Now: afterCreation}); !test.Match(err, wantErr) {
 				t.Errorf("Bad Root: VcekNotRevoked(%v) did not error as expected. Got %v, want %v", signer.Vcek, err, wantErr)
 			}
 
@@ -441,10 +443,57 @@ func TestCRLRootValidity(t *testing.T) {
 				Ask: signer2.Ask,
 			}
 			wantErr2 := "ASK was revoked at 2022-06-14 12:01:00 +0000 UTC"
-			if err := vcekNotRevoked(root2, signer2.Vcek, &Options{Getter: g2}); !test.Match(err, wantErr2) {
+			if err := vcekNotRevoked(root2, signer2.Vcek, &Options{Getter: g2, Now: afterCreation}); !test.Match(err, wantErr2) {
 				t.Errorf("Bad ASK: VcekNotRevoked(%v) did not error as expected. Got %v, want %v", signer.Vcek, err, wantErr2)
 			}
 
+		})
+	}
+}
+
+func TestExpiredCRLRejected(t *testing.T) {
+	signMu.Do(initSigner)
+	trust.ClearProductCertCache()
+	now := time.Date(2022, time.June, 14, 12, 0, 0, 0, time.UTC)
+
+	root := trust.AMDRootCertsProduct(test.GetProductLine())
+	root.ProductCerts = &trust.ProductCerts{
+		Ark: signer.Ark,
+		Ask: signer.Ask,
+	}
+	crlURL := fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/%s/crl", test.GetProductLine())
+
+	for name, tc := range map[string]struct {
+		thisUpdate time.Time
+		nextUpdate time.Time
+		wantErr    string
+	}{
+		"expired": {
+			thisUpdate: now.Add(-48 * time.Hour),
+			nextUpdate: now.Add(-24 * time.Hour),
+			wantErr:    "CRL is expired",
+		},
+		"not yet valid": {
+			thisUpdate: now.Add(24 * time.Hour),
+			nextUpdate: now.Add(48 * time.Hour),
+			wantErr:    "CRL is not yet valid",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			template := &x509.RevocationList{
+				SignatureAlgorithm: x509.SHA384WithRSAPSS,
+				ThisUpdate:         tc.thisUpdate,
+				NextUpdate:         tc.nextUpdate,
+				Number:             big.NewInt(1),
+			}
+			crl, err := x509.CreateRevocationList(insecureRandomness, template, signer.Ark, signer.Keys.Ark)
+			if err != nil {
+				t.Fatal(err)
+			}
+			g := test.SimpleGetter(map[string][]byte{crlURL: crl})
+			if err := VcekNotRevoked(root, signer.Vcek, &Options{Getter: g, Now: now}); !test.Match(err, tc.wantErr) {
+				t.Errorf("VcekNotRevoked(stale CRL) = %v, want error containing %q", err, tc.wantErr)
+			}
 		})
 	}
 }


### PR DESCRIPTION
An attacker on the network can currently serve a stale CRL indefinitely. 
Courtesy @burgerdev for the finding.