### PR TITLE
kds: introduce TCBVersionV0 for StructVersion 0

### DIFF
--- a/kds/kds.go
+++ b/kds/kds.go
@@ -189,83 +189,73 @@ func kdsOidMap(cert *x509.Certificate) (map[kdsOID]*pkix.Extension, error) {
 	return result, nil
 }
 
-// TCBParts represents all TCB field values in a given uint64 representation of
-// an AMD secure processor firmware TCB version.
-type TCBParts struct {
-	// BlSpl is the bootloader security patch level.
-	BlSpl uint8
-	// TeeSpl is the TEE security patch level.
-	TeeSpl uint8
-	// Spl4 is reserved.
-	Spl4 uint8
-	// Spl5 is reserved.
-	Spl5 uint8
-	// Spl6 is reserved.
-	Spl6 uint8
-	// Spl7 is reserved.
-	Spl7 uint8
-	// SnpSpl is the SNP security patch level.
-	SnpSpl uint8
-	// UcodeSpl is the microcode security patch level.
-	UcodeSpl uint8
-}
+// TCBVersionV0 represents the 64-bit packed platform security patch levels for StructVersion 0 (Milan, Genoa, Siena).
+type TCBVersionV0 uint64
 
-// ComposeTCBParts returns an SEV-SNP TCB_VERSION from OID mapping values. The spl4-spl7 fields are
-// reserved, but the KDS specification designates them as 4 byte-sized fields.
-func ComposeTCBParts(parts TCBParts) (TCBVersion, error) {
-	// Only UcodeSpl may be 0-255. All others must be 0-127.
+// BlSpl returns the Bootloader Security Patch Level (AMD TechDocs #57230 Table 10).
+func (t TCBVersionV0) BlSpl() uint8 { return uint8(t & 0xff) }
+
+// TeeSpl returns the TEE Security Patch Level.
+func (t TCBVersionV0) TeeSpl() uint8 { return uint8((t >> 8) & 0xff) }
+
+// Spl4 returns the reserved SPL4 Security Patch Level.
+func (t TCBVersionV0) Spl4() uint8 { return uint8((t >> 16) & 0xff) }
+
+// Spl5 returns the reserved SPL5 Security Patch Level.
+func (t TCBVersionV0) Spl5() uint8 { return uint8((t >> 24) & 0xff) }
+
+// Spl6 returns the reserved SPL6 Security Patch Level.
+func (t TCBVersionV0) Spl6() uint8 { return uint8((t >> 32) & 0xff) }
+
+// Spl7 returns the reserved SPL7 Security Patch Level.
+func (t TCBVersionV0) Spl7() uint8 { return uint8((t >> 40) & 0xff) }
+
+// SnpSpl returns the SNP Security Patch Level.
+func (t TCBVersionV0) SnpSpl() uint8 { return uint8((t >> 48) & 0xff) }
+
+// UcodeSpl returns the Microcode Security Patch Level.
+func (t TCBVersionV0) UcodeSpl() uint8 { return uint8((t >> 56) & 0xff) }
+
+// ComposeTCBVersionV0 constructs a TCBVersionV0 with range checks (0-127 for BL, TEE, SPL4-7, SNP; 0-255 for Ucode).
+func ComposeTCBVersionV0(bl, tee, spl4, spl5, spl6, spl7, snp, ucode uint8) (TCBVersionV0, error) {
 	check127 := func(name string, value uint8) error {
 		if value > 127 {
 			return fmt.Errorf("%s TCB part is %d. Expect 0-127", name, value)
 		}
 		return nil
 	}
-	if err := multierr.Combine(check127("SnpSpl", parts.SnpSpl),
-		check127("Spl7", parts.Spl7),
-		check127("Spl6", parts.Spl6),
-		check127("Spl5", parts.Spl5),
-		check127("Spl4", parts.Spl4),
-		check127("TeeSpl", parts.TeeSpl),
-		check127("BlSpl", parts.BlSpl),
+	if err := multierr.Combine(
+		check127("SnpSpl", snp),
+		check127("Spl7", spl7),
+		check127("Spl6", spl6),
+		check127("Spl5", spl5),
+		check127("Spl4", spl4),
+		check127("TeeSpl", tee),
+		check127("BlSpl", bl),
 	); err != nil {
-		return TCBVersion(0), err
+		return TCBVersionV0(0), err
 	}
-	return TCBVersion(
-		(uint64(parts.UcodeSpl) << 56) |
-			(uint64(parts.SnpSpl) << 48) |
-			(uint64(parts.Spl7) << 40) |
-			(uint64(parts.Spl6) << 32) |
-			(uint64(parts.Spl5) << 24) |
-			(uint64(parts.Spl4) << 16) |
-			(uint64(parts.TeeSpl) << 8) |
-			(uint64(parts.BlSpl) << 0)), nil
+	return TCBVersionV0(
+		(uint64(ucode) << 56) |
+			(uint64(snp) << 48) |
+			(uint64(spl7) << 40) |
+			(uint64(spl6) << 32) |
+			(uint64(spl5) << 24) |
+			(uint64(spl4) << 16) |
+			(uint64(tee) << 8) |
+			(uint64(bl) << 0)), nil
 }
 
-// DecomposeTCBVersion interprets the byte components of the AMD representation of the
-// platform security patch levels into a struct.
-func DecomposeTCBVersion(tcb TCBVersion) TCBParts {
-	return TCBParts{
-		UcodeSpl: uint8((uint64(tcb) >> 56) & 0xff),
-		SnpSpl:   uint8((uint64(tcb) >> 48) & 0xff),
-		Spl7:     uint8((uint64(tcb) >> 40) & 0xff),
-		Spl6:     uint8((uint64(tcb) >> 32) & 0xff),
-		Spl5:     uint8((uint64(tcb) >> 24) & 0xff),
-		Spl4:     uint8((uint64(tcb) >> 16) & 0xff),
-		TeeSpl:   uint8((uint64(tcb) >> 8) & 0xff),
-		BlSpl:    uint8((uint64(tcb) >> 0) & 0xff),
-	}
-}
-
-// TCBPartsLE returns true iff all TCB components of tcb0 are <= the corresponding tcb1 components.
-func TCBPartsLE(tcb0, tcb1 TCBParts) bool {
-	return (tcb0.UcodeSpl <= tcb1.UcodeSpl) &&
-		(tcb0.SnpSpl <= tcb1.SnpSpl) &&
-		(tcb0.Spl7 <= tcb1.Spl7) &&
-		(tcb0.Spl6 <= tcb1.Spl6) &&
-		(tcb0.Spl5 <= tcb1.Spl5) &&
-		(tcb0.Spl4 <= tcb1.Spl4) &&
-		(tcb0.TeeSpl <= tcb1.TeeSpl) &&
-		(tcb0.BlSpl <= tcb1.BlSpl)
+// LE returns true iff all TCB components of t are <= the corresponding components of other.
+func (t TCBVersionV0) LE(other TCBVersionV0) bool {
+	return t.UcodeSpl() <= other.UcodeSpl() &&
+		t.SnpSpl() <= other.SnpSpl() &&
+		t.Spl7() <= other.Spl7() &&
+		t.Spl6() <= other.Spl6() &&
+		t.Spl5() <= other.Spl5() &&
+		t.Spl4() <= other.Spl4() &&
+		t.TeeSpl() <= other.TeeSpl() &&
+		t.BlSpl() <= other.BlSpl()
 }
 
 func asn1U8(ext *pkix.Extension, field string, out *uint8) error {
@@ -382,20 +372,11 @@ func kdsOidMapToExtensions(exts map[kdsOID]*pkix.Extension) (*Extensions, error)
 	if err := asn1U8(exts[kdsUcodeSpl], "UcodeSpl", &ucodespl); err != nil {
 		return nil, err
 	}
-	tcb, err := ComposeTCBParts(TCBParts{
-		BlSpl:    blspl,
-		SnpSpl:   snpspl,
-		TeeSpl:   teespl,
-		Spl4:     spl4,
-		Spl5:     spl5,
-		Spl6:     spl6,
-		Spl7:     spl7,
-		UcodeSpl: ucodespl,
-	})
+	tcb, err := ComposeTCBVersionV0(blspl, teespl, spl4, spl5, spl6, spl7, snpspl, ucodespl)
 	if err != nil {
 		return nil, err
 	}
-	result.TCBVersion = tcb
+	result.TCBVersion = TCBVersion(tcb)
 	return &result, nil
 }
 
@@ -512,28 +493,26 @@ func ProductCertChainURL(s abi.ReportSigner, productLine string) string {
 
 // VCEKCertURL returns the AMD KDS URL for retrieving the VCEK on a given product
 // at a given TCB version. The hwid is the CHIP_ID field in an attestation report.
-func VCEKCertURL(productLine string, hwid []byte, tcb TCBVersion) string {
-	parts := DecomposeTCBVersion(tcb)
+func VCEKCertURL(productLine string, hwid []byte, tcb TCBVersionV0) string {
 	return fmt.Sprintf("%s/%s?blSPL=%d&teeSPL=%d&snpSPL=%d&ucodeSPL=%d",
 		productBaseURL(abi.VcekReportSigner, productLine),
 		hex.EncodeToString(hwid),
-		parts.BlSpl,
-		parts.TeeSpl,
-		parts.SnpSpl,
-		parts.UcodeSpl,
+		tcb.BlSpl(),
+		tcb.TeeSpl(),
+		tcb.SnpSpl(),
+		tcb.UcodeSpl(),
 	)
 }
 
 // VLEKCertURL returns the GET URL for retrieving a VLEK certificate, but without the necessary
 // CSP secret in the HTTP headers that makes the request validate to the KDS.
-func VLEKCertURL(productLine string, tcb TCBVersion) string {
-	parts := DecomposeTCBVersion(tcb)
+func VLEKCertURL(productLine string, tcb TCBVersionV0) string {
 	return fmt.Sprintf("%s/cert?blSPL=%d&teeSPL=%d&snpSPL=%d&ucodeSPL=%d",
 		productBaseURL(abi.VlekReportSigner, productLine),
-		parts.BlSpl,
-		parts.TeeSpl,
-		parts.SnpSpl,
-		parts.UcodeSpl,
+		tcb.BlSpl(),
+		tcb.TeeSpl(),
+		tcb.SnpSpl(),
+		tcb.UcodeSpl(),
 	)
 }
 
@@ -546,7 +525,7 @@ type VCEKCert struct {
 	Product     string
 	ProductLine string
 	HWID        []byte
-	TCB         uint64
+	TCB         TCBVersionV0
 }
 
 // VCEKCertProduct returns a VCEKCert with the product line set to productLine.
@@ -565,7 +544,7 @@ type VLEKCert struct {
 	// Deprecated: Use ProductLine.
 	Product     string
 	ProductLine string
-	TCB         uint64
+	TCB         TCBVersionV0
 }
 
 // CertFunction is an enumeration of which endorsement key type is getting certified.
@@ -639,23 +618,23 @@ func ParseProductCertChainURL(kdsurl string) (string, CertFunction, error) {
 	return parsed.productLine, parsed.function, nil
 }
 
-func parseTCBURL(u *url.URL) (uint64, error) {
+func parseTCBURL(u *url.URL) (TCBVersionV0, error) {
 	values, err := url.ParseQuery(u.RawQuery)
 	if err != nil {
 		return 0, fmt.Errorf("invalid AMD KDS URL query %q: %v", u.RawQuery, err)
 	}
-	parts := TCBParts{}
+	var blSpl, teeSpl, snpSpl, ucodeSpl uint8
 	for key, valuelist := range values {
 		var setter func(number uint8)
 		switch key {
 		case "blSPL":
-			setter = func(number uint8) { parts.BlSpl = number }
+			setter = func(number uint8) { blSpl = number }
 		case "teeSPL":
-			setter = func(number uint8) { parts.TeeSpl = number }
+			setter = func(number uint8) { teeSpl = number }
 		case "snpSPL":
-			setter = func(number uint8) { parts.SnpSpl = number }
+			setter = func(number uint8) { snpSpl = number }
 		case "ucodeSPL":
-			setter = func(number uint8) { parts.UcodeSpl = number }
+			setter = func(number uint8) { ucodeSpl = number }
 		default:
 			return 0, fmt.Errorf("unexpected KDS TCB version URL argument %q", key)
 		}
@@ -667,11 +646,11 @@ func parseTCBURL(u *url.URL) (uint64, error) {
 			setter(uint8(number))
 		}
 	}
-	tcb, err := ComposeTCBParts(parts)
+	tcb, err := ComposeTCBVersionV0(blSpl, teeSpl, 0, 0, 0, 0, snpSpl, ucodeSpl)
 	if err != nil {
 		return 0, fmt.Errorf("invalid AMD KDS TCB arguments: %v", err)
 	}
-	return uint64(tcb), err
+	return tcb, nil
 }
 
 // ParseVCEKCertURL returns the attestation report components represented in the given KDS VCEK

--- a/kds/kds.go
+++ b/kds/kds.go
@@ -114,8 +114,19 @@ var (
 	}
 )
 
-// TCBVersion is a 64-bit bitfield of different security patch levels of AMD firmware and microcode.
-type TCBVersion uint64
+// TCBVersion represents common security patch level accessors across AMD TCB struct versions.
+type TCBVersion interface {
+	// StructVersion returns the AMD TCB structure version.
+	StructVersion() uint8
+	// Uint64 returns the 64-bit wire representation of the TCB.
+	Uint64() uint64
+	// Values encodes the TCB components into KDS REST URL query parameters.
+	Values() url.Values
+	// LE returns true iff all TCB components of this TCB are <= other.
+	LE(other TCBVersion) bool
+	// String returns a human-readable diagnostic representation.
+	String() string
+}
 
 // Extensions represents the information stored in the KDS-specified x509 extensions of a V{C,L}EK
 // certificate.
@@ -189,73 +200,111 @@ func kdsOidMap(cert *x509.Certificate) (map[kdsOID]*pkix.Extension, error) {
 	return result, nil
 }
 
-// TCBVersionV0 represents the 64-bit packed platform security patch levels for StructVersion 0 (Milan, Genoa, Siena).
-type TCBVersionV0 uint64
+// TCBVersionV0 represents the platform security patch levels for StructVersion 0 (Milan, Genoa, Siena).
+type TCBVersionV0 struct {
+	BlSpl    uint8
+	TeeSpl   uint8
+	Spl4     uint8
+	Spl5     uint8
+	Spl6     uint8
+	Spl7     uint8
+	SnpSpl   uint8
+	UcodeSpl uint8
+}
 
-// BlSpl returns the Bootloader Security Patch Level (AMD TechDocs #57230 Table 10).
-func (t TCBVersionV0) BlSpl() uint8 { return uint8(t & 0xff) }
+// StructVersion returns 0 for Milan, Genoa, and Siena.
+func (t TCBVersionV0) StructVersion() uint8 { return 0 }
 
-// TeeSpl returns the TEE Security Patch Level.
-func (t TCBVersionV0) TeeSpl() uint8 { return uint8((t >> 8) & 0xff) }
+// Uint64 returns the 64-bit wire representation of TCBVersionV0.
+func (t TCBVersionV0) Uint64() uint64 {
+	return (uint64(t.UcodeSpl) << 56) |
+		(uint64(t.SnpSpl) << 48) |
+		(uint64(t.Spl7) << 40) |
+		(uint64(t.Spl6) << 32) |
+		(uint64(t.Spl5) << 24) |
+		(uint64(t.Spl4) << 16) |
+		(uint64(t.TeeSpl) << 8) |
+		(uint64(t.BlSpl) << 0)
+}
 
-// Spl4 returns the reserved SPL4 Security Patch Level.
-func (t TCBVersionV0) Spl4() uint8 { return uint8((t >> 16) & 0xff) }
-
-// Spl5 returns the reserved SPL5 Security Patch Level.
-func (t TCBVersionV0) Spl5() uint8 { return uint8((t >> 24) & 0xff) }
-
-// Spl6 returns the reserved SPL6 Security Patch Level.
-func (t TCBVersionV0) Spl6() uint8 { return uint8((t >> 32) & 0xff) }
-
-// Spl7 returns the reserved SPL7 Security Patch Level.
-func (t TCBVersionV0) Spl7() uint8 { return uint8((t >> 40) & 0xff) }
-
-// SnpSpl returns the SNP Security Patch Level.
-func (t TCBVersionV0) SnpSpl() uint8 { return uint8((t >> 48) & 0xff) }
-
-// UcodeSpl returns the Microcode Security Patch Level.
-func (t TCBVersionV0) UcodeSpl() uint8 { return uint8((t >> 56) & 0xff) }
-
-// ComposeTCBVersionV0 constructs a TCBVersionV0 with range checks (0-127 for BL, TEE, SPL4-7, SNP; 0-255 for Ucode).
-func ComposeTCBVersionV0(bl, tee, spl4, spl5, spl6, spl7, snp, ucode uint8) (TCBVersionV0, error) {
-	check127 := func(name string, value uint8) error {
-		if value > 127 {
-			return fmt.Errorf("%s TCB part is %d. Expect 0-127", name, value)
-		}
-		return nil
-	}
-	if err := multierr.Combine(
-		check127("SnpSpl", snp),
-		check127("Spl7", spl7),
-		check127("Spl6", spl6),
-		check127("Spl5", spl5),
-		check127("Spl4", spl4),
-		check127("TeeSpl", tee),
-		check127("BlSpl", bl),
-	); err != nil {
-		return TCBVersionV0(0), err
-	}
-	return TCBVersionV0(
-		(uint64(ucode) << 56) |
-			(uint64(snp) << 48) |
-			(uint64(spl7) << 40) |
-			(uint64(spl6) << 32) |
-			(uint64(spl5) << 24) |
-			(uint64(spl4) << 16) |
-			(uint64(tee) << 8) |
-			(uint64(bl) << 0)), nil
+// Values encodes TCBVersionV0 into KDS REST URL query parameters.
+func (t TCBVersionV0) Values() url.Values {
+	values := make(url.Values)
+	values.Set("blSPL", fmt.Sprintf("%d", t.BlSpl))
+	values.Set("teeSPL", fmt.Sprintf("%d", t.TeeSpl))
+	values.Set("snpSPL", fmt.Sprintf("%d", t.SnpSpl))
+	values.Set("ucodeSPL", fmt.Sprintf("%d", t.UcodeSpl))
+	return values
 }
 
 // LE returns true iff all TCB components of t are <= the corresponding components of other.
-func (t TCBVersionV0) LE(other TCBVersionV0) bool {
-	return t.UcodeSpl() <= other.UcodeSpl() &&
-		t.SnpSpl() <= other.SnpSpl() &&
-		t.Spl7() <= other.Spl7() &&
-		t.Spl6() <= other.Spl6() &&
-		t.Spl5() <= other.Spl5() &&
-		t.Spl4() <= other.Spl4() &&
-		t.TeeSpl() <= other.TeeSpl() &&
-		t.BlSpl() <= other.BlSpl()
+func (t TCBVersionV0) LE(other TCBVersion) bool {
+	o, ok := other.(TCBVersionV0)
+	if !ok {
+		return false
+	}
+	return t.UcodeSpl <= o.UcodeSpl &&
+		t.SnpSpl <= o.SnpSpl &&
+		t.Spl7 <= o.Spl7 &&
+		t.Spl6 <= o.Spl6 &&
+		t.Spl5 <= o.Spl5 &&
+		t.Spl4 <= o.Spl4 &&
+		t.TeeSpl <= o.TeeSpl &&
+		t.BlSpl <= o.BlSpl
+}
+
+func (t TCBVersionV0) String() string {
+	return fmt.Sprintf("{BlSpl:%d TeeSpl:%d Spl4:%d Spl5:%d Spl6:%d Spl7:%d SnpSpl:%d UcodeSpl:%d}",
+		t.BlSpl, t.TeeSpl, t.Spl4, t.Spl5, t.Spl6, t.Spl7, t.SnpSpl, t.UcodeSpl)
+}
+
+// DecomposeTCBVersionV0 decomposes a 64-bit raw TCB integer into a TCBVersionV0.
+func DecomposeTCBVersionV0(raw uint64) TCBVersionV0 {
+	return TCBVersionV0{
+		BlSpl:    uint8(raw & 0xff),
+		TeeSpl:   uint8((raw >> 8) & 0xff),
+		Spl4:     uint8((raw >> 16) & 0xff),
+		Spl5:     uint8((raw >> 24) & 0xff),
+		Spl6:     uint8((raw >> 32) & 0xff),
+		Spl7:     uint8((raw >> 40) & 0xff),
+		SnpSpl:   uint8((raw >> 48) & 0xff),
+		UcodeSpl: uint8((raw >> 56) & 0xff),
+	}
+}
+
+// ParseTCBVersionV0 parses KDS REST query parameters into a TCBVersionV0.
+func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
+	var blSpl, teeSpl, snpSpl, ucodeSpl uint8
+	for key, valuelist := range values {
+		var setter func(number uint8)
+		maxVal := 127
+		switch key {
+		case "blSPL":
+			setter = func(number uint8) { blSpl = number }
+		case "teeSPL":
+			setter = func(number uint8) { teeSpl = number }
+		case "snpSPL":
+			setter = func(number uint8) { snpSpl = number }
+		case "ucodeSPL":
+			maxVal = 255
+			setter = func(number uint8) { ucodeSpl = number }
+		default:
+			return TCBVersionV0{}, fmt.Errorf("unexpected KDS TCB version URL argument %q", key)
+		}
+		for _, val := range valuelist {
+			number, err := strconv.Atoi(val)
+			if err != nil || number < 0 || number > maxVal {
+				return TCBVersionV0{}, fmt.Errorf("invalid KDS TCB version URL argument value %q, want a value 0-%d", val, maxVal)
+			}
+			setter(uint8(number))
+		}
+	}
+	return TCBVersionV0{
+		BlSpl:    blSpl,
+		TeeSpl:   teeSpl,
+		SnpSpl:   snpSpl,
+		UcodeSpl: ucodeSpl,
+	}, nil
 }
 
 func asn1U8(ext *pkix.Extension, field string, out *uint8) error {
@@ -372,11 +421,16 @@ func kdsOidMapToExtensions(exts map[kdsOID]*pkix.Extension) (*Extensions, error)
 	if err := asn1U8(exts[kdsUcodeSpl], "UcodeSpl", &ucodespl); err != nil {
 		return nil, err
 	}
-	tcb, err := ComposeTCBVersionV0(blspl, teespl, spl4, spl5, spl6, spl7, snpspl, ucodespl)
-	if err != nil {
-		return nil, err
+	result.TCBVersion = TCBVersionV0{
+		BlSpl:    blspl,
+		TeeSpl:   teespl,
+		Spl4:     spl4,
+		Spl5:     spl5,
+		Spl6:     spl6,
+		Spl7:     spl7,
+		SnpSpl:   snpspl,
+		UcodeSpl: ucodespl,
 	}
-	result.TCBVersion = TCBVersion(tcb)
 	return &result, nil
 }
 
@@ -493,26 +547,20 @@ func ProductCertChainURL(s abi.ReportSigner, productLine string) string {
 
 // VCEKCertURL returns the AMD KDS URL for retrieving the VCEK on a given product
 // at a given TCB version. The hwid is the CHIP_ID field in an attestation report.
-func VCEKCertURL(productLine string, hwid []byte, tcb TCBVersionV0) string {
-	return fmt.Sprintf("%s/%s?blSPL=%d&teeSPL=%d&snpSPL=%d&ucodeSPL=%d",
+func VCEKCertURL(productLine string, hwid []byte, tcb TCBVersion) string {
+	return fmt.Sprintf("%s/%s?%s",
 		productBaseURL(abi.VcekReportSigner, productLine),
 		hex.EncodeToString(hwid),
-		tcb.BlSpl(),
-		tcb.TeeSpl(),
-		tcb.SnpSpl(),
-		tcb.UcodeSpl(),
+		tcb.Values().Encode(),
 	)
 }
 
 // VLEKCertURL returns the GET URL for retrieving a VLEK certificate, but without the necessary
 // CSP secret in the HTTP headers that makes the request validate to the KDS.
-func VLEKCertURL(productLine string, tcb TCBVersionV0) string {
-	return fmt.Sprintf("%s/cert?blSPL=%d&teeSPL=%d&snpSPL=%d&ucodeSPL=%d",
+func VLEKCertURL(productLine string, tcb TCBVersion) string {
+	return fmt.Sprintf("%s/cert?%s",
 		productBaseURL(abi.VlekReportSigner, productLine),
-		tcb.BlSpl(),
-		tcb.TeeSpl(),
-		tcb.SnpSpl(),
-		tcb.UcodeSpl(),
+		tcb.Values().Encode(),
 	)
 }
 
@@ -525,7 +573,7 @@ type VCEKCert struct {
 	Product     string
 	ProductLine string
 	HWID        []byte
-	TCB         TCBVersionV0
+	TCB         TCBVersion
 }
 
 // VCEKCertProduct returns a VCEKCert with the product line set to productLine.
@@ -544,7 +592,7 @@ type VLEKCert struct {
 	// Deprecated: Use ProductLine.
 	Product     string
 	ProductLine string
-	TCB         TCBVersionV0
+	TCB         TCBVersion
 }
 
 // CertFunction is an enumeration of which endorsement key type is getting certified.
@@ -621,36 +669,9 @@ func ParseProductCertChainURL(kdsurl string) (string, CertFunction, error) {
 func parseTCBURL(u *url.URL) (TCBVersionV0, error) {
 	values, err := url.ParseQuery(u.RawQuery)
 	if err != nil {
-		return 0, fmt.Errorf("invalid AMD KDS URL query %q: %v", u.RawQuery, err)
+		return TCBVersionV0{}, fmt.Errorf("invalid AMD KDS URL query %q: %v", u.RawQuery, err)
 	}
-	var blSpl, teeSpl, snpSpl, ucodeSpl uint8
-	for key, valuelist := range values {
-		var setter func(number uint8)
-		switch key {
-		case "blSPL":
-			setter = func(number uint8) { blSpl = number }
-		case "teeSPL":
-			setter = func(number uint8) { teeSpl = number }
-		case "snpSPL":
-			setter = func(number uint8) { snpSpl = number }
-		case "ucodeSPL":
-			setter = func(number uint8) { ucodeSpl = number }
-		default:
-			return 0, fmt.Errorf("unexpected KDS TCB version URL argument %q", key)
-		}
-		for _, val := range valuelist {
-			number, err := strconv.Atoi(val)
-			if err != nil || number < 0 || number > 255 {
-				return 0, fmt.Errorf("invalid KDS TCB version URL argument value %q, want a value 0-255", val)
-			}
-			setter(uint8(number))
-		}
-	}
-	tcb, err := ComposeTCBVersionV0(blSpl, teeSpl, 0, 0, 0, 0, snpSpl, ucodeSpl)
-	if err != nil {
-		return 0, fmt.Errorf("invalid AMD KDS TCB arguments: %v", err)
-	}
-	return tcb, nil
+	return ParseTCBVersionV0(values)
 }
 
 // ParseVCEKCertURL returns the attestation report components represented in the given KDS VCEK

--- a/kds/kds.go
+++ b/kds/kds.go
@@ -202,13 +202,21 @@ func kdsOidMap(cert *x509.Certificate) (map[kdsOID]*pkix.Extension, error) {
 
 // TCBVersionV0 represents the platform security patch levels for StructVersion 0 (Milan, Genoa, Siena).
 type TCBVersionV0 struct {
-	BlSpl    uint8
-	TeeSpl   uint8
-	Spl4     uint8
-	Spl5     uint8
-	Spl6     uint8
-	Spl7     uint8
-	SnpSpl   uint8
+	// BlSpl is the bootloader security patch level.
+	BlSpl uint8
+	// TeeSpl is the TEE security patch level.
+	TeeSpl uint8
+	// Spl4 is reserved.
+	Spl4 uint8
+	// Spl5 is reserved.
+	Spl5 uint8
+	// Spl6 is reserved.
+	Spl6 uint8
+	// Spl7 is reserved.
+	Spl7 uint8
+	// SnpSpl is the SNP security patch level.
+	SnpSpl uint8
+	// UcodeSpl is the microcode security patch level.
 	UcodeSpl uint8
 }
 

--- a/kds/kds_test.go
+++ b/kds/kds_test.go
@@ -40,8 +40,8 @@ func TestVCEKCertURL(t *testing.T) {
 	hwid := make([]byte, abi.ChipIDSize)
 	hwid[0] = 0xfe
 	hwid[abi.ChipIDSize-1] = 0xc0
-	got := VCEKCertURL("Milan", hwid, TCBVersionV0(0))
-	want := "https://kdsintf.amd.com/vcek/v1/Milan/fe0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0?blSPL=0&teeSPL=0&snpSPL=0&ucodeSPL=0"
+	got := VCEKCertURL("Milan", hwid, TCBVersionV0{})
+	want := "https://kdsintf.amd.com/vcek/v1/Milan/fe0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0?blSPL=0&snpSPL=0&teeSPL=0&ucodeSPL=0"
 	if got != want {
 		t.Errorf("VCEKCertURL(\"Milan\", %v, 0) = %q, want %q", hwid, got, want)
 	}
@@ -139,11 +139,11 @@ func TestParseVCEKCertURL(t *testing.T) {
 	}{
 		{
 			name: "happy path",
-			url:  VCEKCertURL("Milan", hwid, TCBVersionV0(0)),
+			url:  VCEKCertURL("Milan", hwid, TCBVersionV0{}),
 			want: func() VCEKCert {
 				c := VCEKCertProduct("Milan")
 				c.HWID = hwid
-				c.TCB = 0
+				c.TCB = TCBVersionV0{}
 				return c
 			}(),
 		},
@@ -160,12 +160,17 @@ func TestParseVCEKCertURL(t *testing.T) {
 		{
 			name:    "bad query argument numerical",
 			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Milan/%s?blSPL=-4", hwidhex),
-			wantErr: "invalid KDS TCB version URL argument value \"-4\", want a value 0-255",
+			wantErr: "invalid KDS TCB version URL argument value \"-4\", want a value 0-127",
 		},
 		{
 			name:    "bad query argument numerical",
 			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Milan/%s?blSPL=alpha", hwidhex),
-			wantErr: "invalid KDS TCB version URL argument value \"alpha\", want a value 0-255",
+			wantErr: "invalid KDS TCB version URL argument value \"alpha\", want a value 0-127",
+		},
+		{
+			name:    "query argument exceeds 127 for blSPL",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Milan/%s?blSPL=128", hwidhex),
+			wantErr: "invalid KDS TCB version URL argument value \"128\", want a value 0-127",
 		},
 	}
 	for _, tc := range tcs {
@@ -318,65 +323,73 @@ func TestParseProductName(t *testing.T) {
 }
 
 func TestTCBVersionV0(t *testing.T) {
-	tcb, err := ComposeTCBVersionV0(1, 2, 3, 4, 5, 6, 7, 8)
+	tcb := TCBVersionV0{
+		BlSpl:    1,
+		TeeSpl:   2,
+		Spl4:     3,
+		Spl5:     4,
+		Spl6:     5,
+		Spl7:     6,
+		SnpSpl:   7,
+		UcodeSpl: 8,
+	}
+	if tcb.BlSpl != 1 || tcb.TeeSpl != 2 || tcb.Spl4 != 3 || tcb.Spl5 != 4 ||
+		tcb.Spl6 != 5 || tcb.Spl7 != 6 || tcb.SnpSpl != 7 || tcb.UcodeSpl != 8 {
+		t.Errorf("TCBVersionV0 fields failed: got bl=%d tee=%d spl4=%d spl5=%d spl6=%d spl7=%d snp=%d ucode=%d",
+			tcb.BlSpl, tcb.TeeSpl, tcb.Spl4, tcb.Spl5, tcb.Spl6, tcb.Spl7, tcb.SnpSpl, tcb.UcodeSpl)
+	}
+	if tcb.StructVersion() != 0 {
+		t.Errorf("StructVersion() = %d, want 0", tcb.StructVersion())
+	}
+
+	raw := tcb.Uint64()
+	decomposed := DecomposeTCBVersionV0(raw)
+	if decomposed != tcb {
+		t.Errorf("DecomposeTCBVersionV0(0x%x) = %+v, want %+v", raw, decomposed, tcb)
+	}
+
+	vals := tcb.Values()
+	parsed, err := ParseTCBVersionV0(vals)
 	if err != nil {
-		t.Fatalf("ComposeTCBVersionV0 failed: %v", err)
+		t.Fatalf("ParseTCBVersionV0(%v) failed: %v", vals, err)
 	}
-	if tcb.BlSpl() != 1 || tcb.TeeSpl() != 2 || tcb.Spl4() != 3 || tcb.Spl5() != 4 ||
-		tcb.Spl6() != 5 || tcb.Spl7() != 6 || tcb.SnpSpl() != 7 || tcb.UcodeSpl() != 8 {
-		t.Errorf("TCBVersionV0 accessors failed: got bl=%d tee=%d spl4=%d spl5=%d spl6=%d spl7=%d snp=%d ucode=%d",
-			tcb.BlSpl(), tcb.TeeSpl(), tcb.Spl4(), tcb.Spl5(), tcb.Spl6(), tcb.Spl7(), tcb.SnpSpl(), tcb.UcodeSpl())
-	}
-
-	// Range validation tests (0-127 for bl, tee, spl4-7, snp; 0-255 for ucode).
-	invalidCases := []struct {
-		name                                        string
-		bl, tee, spl4, spl5, spl6, spl7, snp, ucode uint8
-	}{
-		{"BlSpl > 127", 128, 0, 0, 0, 0, 0, 0, 0},
-		{"TeeSpl > 127", 0, 128, 0, 0, 0, 0, 0, 0},
-		{"Spl4 > 127", 0, 0, 128, 0, 0, 0, 0, 0},
-		{"Spl5 > 127", 0, 0, 0, 128, 0, 0, 0, 0},
-		{"Spl6 > 127", 0, 0, 0, 0, 128, 0, 0, 0},
-		{"Spl7 > 127", 0, 0, 0, 0, 0, 128, 0, 0},
-		{"SnpSpl > 127", 0, 0, 0, 0, 0, 0, 128, 0},
-	}
-	for _, tc := range invalidCases {
-		if _, err := ComposeTCBVersionV0(tc.bl, tc.tee, tc.spl4, tc.spl5, tc.spl6, tc.spl7, tc.snp, tc.ucode); err == nil {
-			t.Errorf("ComposeTCBVersionV0(%s) expected error, got nil", tc.name)
-		}
-	}
-
-	// UcodeSpl can be up to 255 without error.
-	if _, err := ComposeTCBVersionV0(127, 127, 127, 127, 127, 127, 127, 255); err != nil {
-		t.Errorf("ComposeTCBVersionV0 with ucode=255 returned unexpected error: %v", err)
+	if parsed != (TCBVersionV0{BlSpl: 1, TeeSpl: 2, SnpSpl: 7, UcodeSpl: 8}) {
+		t.Errorf("ParseTCBVersionV0(%v) = %+v, want %+v", vals, parsed, tcb)
 	}
 
 	// Component-wise LE tests across all 8 fields.
-	base, _ := ComposeTCBVersionV0(10, 10, 10, 10, 10, 10, 10, 10)
+	base := TCBVersionV0{
+		BlSpl:    10,
+		TeeSpl:   10,
+		Spl4:     10,
+		Spl5:     10,
+		Spl6:     10,
+		Spl7:     10,
+		SnpSpl:   10,
+		UcodeSpl: 10,
+	}
 	if !base.LE(base) {
 		t.Errorf("expected base.LE(base) to be true")
 	}
 
 	higherFields := []struct {
-		name                                        string
-		bl, tee, spl4, spl5, spl6, spl7, snp, ucode uint8
+		name string
+		tcb  TCBVersionV0
 	}{
-		{"BlSpl", 11, 10, 10, 10, 10, 10, 10, 10},
-		{"TeeSpl", 10, 11, 10, 10, 10, 10, 10, 10},
-		{"Spl4", 10, 10, 11, 10, 10, 10, 10, 10},
-		{"Spl5", 10, 10, 10, 11, 10, 10, 10, 10},
-		{"Spl6", 10, 10, 10, 10, 11, 10, 10, 10},
-		{"Spl7", 10, 10, 10, 10, 10, 11, 10, 10},
-		{"SnpSpl", 10, 10, 10, 10, 10, 10, 11, 10},
-		{"UcodeSpl", 10, 10, 10, 10, 10, 10, 10, 11},
+		{"BlSpl", TCBVersionV0{BlSpl: 11, TeeSpl: 10, Spl4: 10, Spl5: 10, Spl6: 10, Spl7: 10, SnpSpl: 10, UcodeSpl: 10}},
+		{"TeeSpl", TCBVersionV0{BlSpl: 10, TeeSpl: 11, Spl4: 10, Spl5: 10, Spl6: 10, Spl7: 10, SnpSpl: 10, UcodeSpl: 10}},
+		{"Spl4", TCBVersionV0{BlSpl: 10, TeeSpl: 10, Spl4: 11, Spl5: 10, Spl6: 10, Spl7: 10, SnpSpl: 10, UcodeSpl: 10}},
+		{"Spl5", TCBVersionV0{BlSpl: 10, TeeSpl: 10, Spl4: 10, Spl5: 11, Spl6: 10, Spl7: 10, SnpSpl: 10, UcodeSpl: 10}},
+		{"Spl6", TCBVersionV0{BlSpl: 10, TeeSpl: 10, Spl4: 10, Spl5: 10, Spl6: 11, Spl7: 10, SnpSpl: 10, UcodeSpl: 10}},
+		{"Spl7", TCBVersionV0{BlSpl: 10, TeeSpl: 10, Spl4: 10, Spl5: 10, Spl6: 10, Spl7: 11, SnpSpl: 10, UcodeSpl: 10}},
+		{"SnpSpl", TCBVersionV0{BlSpl: 10, TeeSpl: 10, Spl4: 10, Spl5: 10, Spl6: 10, Spl7: 10, SnpSpl: 11, UcodeSpl: 10}},
+		{"UcodeSpl", TCBVersionV0{BlSpl: 10, TeeSpl: 10, Spl4: 10, Spl5: 10, Spl6: 10, Spl7: 10, SnpSpl: 10, UcodeSpl: 11}},
 	}
 	for _, tc := range higherFields {
-		higher, _ := ComposeTCBVersionV0(tc.bl, tc.tee, tc.spl4, tc.spl5, tc.spl6, tc.spl7, tc.snp, tc.ucode)
-		if !base.LE(higher) {
+		if !base.LE(tc.tcb) {
 			t.Errorf("expected base.LE(higher for %s) to be true", tc.name)
 		}
-		if higher.LE(base) {
+		if tc.tcb.LE(base) {
 			t.Errorf("expected higher.LE(base for %s) to be false", tc.name)
 		}
 	}

--- a/kds/kds_test.go
+++ b/kds/kds_test.go
@@ -40,7 +40,7 @@ func TestVCEKCertURL(t *testing.T) {
 	hwid := make([]byte, abi.ChipIDSize)
 	hwid[0] = 0xfe
 	hwid[abi.ChipIDSize-1] = 0xc0
-	got := VCEKCertURL("Milan", hwid, TCBVersion(0))
+	got := VCEKCertURL("Milan", hwid, TCBVersionV0(0))
 	want := "https://kdsintf.amd.com/vcek/v1/Milan/fe0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0?blSPL=0&teeSPL=0&snpSPL=0&ucodeSPL=0"
 	if got != want {
 		t.Errorf("VCEKCertURL(\"Milan\", %v, 0) = %q, want %q", hwid, got, want)
@@ -139,7 +139,7 @@ func TestParseVCEKCertURL(t *testing.T) {
 	}{
 		{
 			name: "happy path",
-			url:  VCEKCertURL("Milan", hwid, TCBVersion(0)),
+			url:  VCEKCertURL("Milan", hwid, TCBVersionV0(0)),
 			want: func() VCEKCert {
 				c := VCEKCertProduct("Milan")
 				c.HWID = hwid
@@ -314,5 +314,70 @@ func TestParseProductName(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTCBVersionV0(t *testing.T) {
+	tcb, err := ComposeTCBVersionV0(1, 2, 3, 4, 5, 6, 7, 8)
+	if err != nil {
+		t.Fatalf("ComposeTCBVersionV0 failed: %v", err)
+	}
+	if tcb.BlSpl() != 1 || tcb.TeeSpl() != 2 || tcb.Spl4() != 3 || tcb.Spl5() != 4 ||
+		tcb.Spl6() != 5 || tcb.Spl7() != 6 || tcb.SnpSpl() != 7 || tcb.UcodeSpl() != 8 {
+		t.Errorf("TCBVersionV0 accessors failed: got bl=%d tee=%d spl4=%d spl5=%d spl6=%d spl7=%d snp=%d ucode=%d",
+			tcb.BlSpl(), tcb.TeeSpl(), tcb.Spl4(), tcb.Spl5(), tcb.Spl6(), tcb.Spl7(), tcb.SnpSpl(), tcb.UcodeSpl())
+	}
+
+	// Range validation tests (0-127 for bl, tee, spl4-7, snp; 0-255 for ucode).
+	invalidCases := []struct {
+		name                                        string
+		bl, tee, spl4, spl5, spl6, spl7, snp, ucode uint8
+	}{
+		{"BlSpl > 127", 128, 0, 0, 0, 0, 0, 0, 0},
+		{"TeeSpl > 127", 0, 128, 0, 0, 0, 0, 0, 0},
+		{"Spl4 > 127", 0, 0, 128, 0, 0, 0, 0, 0},
+		{"Spl5 > 127", 0, 0, 0, 128, 0, 0, 0, 0},
+		{"Spl6 > 127", 0, 0, 0, 0, 128, 0, 0, 0},
+		{"Spl7 > 127", 0, 0, 0, 0, 0, 128, 0, 0},
+		{"SnpSpl > 127", 0, 0, 0, 0, 0, 0, 128, 0},
+	}
+	for _, tc := range invalidCases {
+		if _, err := ComposeTCBVersionV0(tc.bl, tc.tee, tc.spl4, tc.spl5, tc.spl6, tc.spl7, tc.snp, tc.ucode); err == nil {
+			t.Errorf("ComposeTCBVersionV0(%s) expected error, got nil", tc.name)
+		}
+	}
+
+	// UcodeSpl can be up to 255 without error.
+	if _, err := ComposeTCBVersionV0(127, 127, 127, 127, 127, 127, 127, 255); err != nil {
+		t.Errorf("ComposeTCBVersionV0 with ucode=255 returned unexpected error: %v", err)
+	}
+
+	// Component-wise LE tests across all 8 fields.
+	base, _ := ComposeTCBVersionV0(10, 10, 10, 10, 10, 10, 10, 10)
+	if !base.LE(base) {
+		t.Errorf("expected base.LE(base) to be true")
+	}
+
+	higherFields := []struct {
+		name                                        string
+		bl, tee, spl4, spl5, spl6, spl7, snp, ucode uint8
+	}{
+		{"BlSpl", 11, 10, 10, 10, 10, 10, 10, 10},
+		{"TeeSpl", 10, 11, 10, 10, 10, 10, 10, 10},
+		{"Spl4", 10, 10, 11, 10, 10, 10, 10, 10},
+		{"Spl5", 10, 10, 10, 11, 10, 10, 10, 10},
+		{"Spl6", 10, 10, 10, 10, 11, 10, 10, 10},
+		{"Spl7", 10, 10, 10, 10, 10, 11, 10, 10},
+		{"SnpSpl", 10, 10, 10, 10, 10, 10, 11, 10},
+		{"UcodeSpl", 10, 10, 10, 10, 10, 10, 10, 11},
+	}
+	for _, tc := range higherFields {
+		higher, _ := ComposeTCBVersionV0(tc.bl, tc.tee, tc.spl4, tc.spl5, tc.spl6, tc.spl7, tc.snp, tc.ucode)
+		if !base.LE(higher) {
+			t.Errorf("expected base.LE(higher for %s) to be true", tc.name)
+		}
+		if higher.LE(base) {
+			t.Errorf("expected higher.LE(base for %s) to be false", tc.name)
+		}
 	}
 }

--- a/testing/fake_certs.go
+++ b/testing/fake_certs.go
@@ -386,9 +386,9 @@ func (b *AmdSignerBuilder) certifyAsvk() error {
 	return err
 }
 
-// CustomExtensions returns an array of extensions following the KDS specification
+// CustomExtensionsV0 returns an array of StructVersion 0 extensions following the KDS specification
 // for the given values.
-func CustomExtensions(tcb kds.TCBParts, hwid []byte, cspid, productName string) []pkix.Extension {
+func CustomExtensionsV0(tcb kds.TCBVersionV0, hwid []byte, cspid, productName string) []pkix.Extension {
 	var productNameAsn1 []byte
 	asn1Zero, _ := asn1.Marshal(0)
 	if hwid != nil {
@@ -398,14 +398,14 @@ func CustomExtensions(tcb kds.TCBParts, hwid []byte, cspid, productName string) 
 		// VLEK doesn't have a -stepping component to its productName.
 		productNameAsn1, _ = asn1.MarshalWithParams(parts[0], "ia5")
 	}
-	blSpl, _ := asn1.Marshal(int(tcb.BlSpl))
-	teeSpl, _ := asn1.Marshal(int(tcb.TeeSpl))
-	snpSpl, _ := asn1.Marshal(int(tcb.SnpSpl))
-	spl4, _ := asn1.Marshal(int(tcb.Spl4))
-	spl5, _ := asn1.Marshal(int(tcb.Spl5))
-	spl6, _ := asn1.Marshal(int(tcb.Spl6))
-	spl7, _ := asn1.Marshal(int(tcb.Spl7))
-	ucodeSpl, _ := asn1.Marshal(int(tcb.UcodeSpl))
+	blSpl, _ := asn1.Marshal(int(tcb.BlSpl()))
+	teeSpl, _ := asn1.Marshal(int(tcb.TeeSpl()))
+	snpSpl, _ := asn1.Marshal(int(tcb.SnpSpl()))
+	spl4, _ := asn1.Marshal(int(tcb.Spl4()))
+	spl5, _ := asn1.Marshal(int(tcb.Spl5()))
+	spl6, _ := asn1.Marshal(int(tcb.Spl6()))
+	spl7, _ := asn1.Marshal(int(tcb.Spl7()))
+	ucodeSpl, _ := asn1.Marshal(int(tcb.UcodeSpl()))
 	exts := []pkix.Extension{
 		{Id: kds.OidStructVersion, Value: asn1Zero},
 		{Id: kds.OidProductName1, Value: productNameAsn1},
@@ -447,7 +447,7 @@ func (b *AmdSignerBuilder) endorsementKeyPrecert(creationTime time.Time, hwid []
 		SerialNumber:       serialNumber,
 		NotBefore:          time.Time{},
 		NotAfter:           creationTime.Add(vcekExpirationYears * 365 * 24 * time.Hour),
-		ExtraExtensions:    CustomExtensions(kds.TCBParts{}, hwid, b.CSPID, b.productName()),
+		ExtraExtensions:    CustomExtensionsV0(kds.TCBVersionV0(0), hwid, b.CSPID, b.productName()),
 	}
 }
 

--- a/testing/fake_certs.go
+++ b/testing/fake_certs.go
@@ -398,14 +398,14 @@ func CustomExtensionsV0(tcb kds.TCBVersionV0, hwid []byte, cspid, productName st
 		// VLEK doesn't have a -stepping component to its productName.
 		productNameAsn1, _ = asn1.MarshalWithParams(parts[0], "ia5")
 	}
-	blSpl, _ := asn1.Marshal(int(tcb.BlSpl()))
-	teeSpl, _ := asn1.Marshal(int(tcb.TeeSpl()))
-	snpSpl, _ := asn1.Marshal(int(tcb.SnpSpl()))
-	spl4, _ := asn1.Marshal(int(tcb.Spl4()))
-	spl5, _ := asn1.Marshal(int(tcb.Spl5()))
-	spl6, _ := asn1.Marshal(int(tcb.Spl6()))
-	spl7, _ := asn1.Marshal(int(tcb.Spl7()))
-	ucodeSpl, _ := asn1.Marshal(int(tcb.UcodeSpl()))
+	blSpl, _ := asn1.Marshal(int(tcb.BlSpl))
+	teeSpl, _ := asn1.Marshal(int(tcb.TeeSpl))
+	snpSpl, _ := asn1.Marshal(int(tcb.SnpSpl))
+	spl4, _ := asn1.Marshal(int(tcb.Spl4))
+	spl5, _ := asn1.Marshal(int(tcb.Spl5))
+	spl6, _ := asn1.Marshal(int(tcb.Spl6))
+	spl7, _ := asn1.Marshal(int(tcb.Spl7))
+	ucodeSpl, _ := asn1.Marshal(int(tcb.UcodeSpl))
 	exts := []pkix.Extension{
 		{Id: kds.OidStructVersion, Value: asn1Zero},
 		{Id: kds.OidProductName1, Value: productNameAsn1},
@@ -447,7 +447,7 @@ func (b *AmdSignerBuilder) endorsementKeyPrecert(creationTime time.Time, hwid []
 		SerialNumber:       serialNumber,
 		NotBefore:          time.Time{},
 		NotAfter:           creationTime.Add(vcekExpirationYears * 365 * 24 * time.Hour),
-		ExtraExtensions:    CustomExtensionsV0(kds.TCBVersionV0(0), hwid, b.CSPID, b.productName()),
+		ExtraExtensions:    CustomExtensionsV0(kds.TCBVersionV0{}, hwid, b.CSPID, b.productName()),
 	}
 }
 

--- a/testing/fakekds.go
+++ b/testing/fakekds.go
@@ -116,11 +116,15 @@ func FakeKDSFromFile(path string) (*FakeKDS, error) {
 func FakeKDSFromSigner(signer *AmdSigner) (*FakeKDS, error) {
 	certs := &kpb.Certificates{}
 	rootBundles := map[string]*RootBundle{}
+	tcbVal := uint64(0)
+	if signer.TCB != nil {
+		tcbVal = signer.TCB.Uint64()
+	}
 	certs.ChipCerts = []*kpb.Certificates_ChipTCBCerts{
 		{
 			ChipId: signer.HWID[:],
 			TcbCerts: map[uint64][]byte{
-				uint64(signer.TCB): signer.Vcek.Raw,
+				tcbVal: signer.Vcek.Raw,
 			},
 			Fms: abi.MaskedCpuid1EaxFromSevProduct(signer.Product),
 		},
@@ -187,7 +191,7 @@ func (f *FakeKDS) Get(url string) ([]byte, error) {
 	if certs == nil {
 		return nil, fmt.Errorf("no certificate found at %q (unknown HWID %v)", url, vcek.HWID)
 	}
-	certbytes, ok := certs[uint64(vcek.TCB)]
+	certbytes, ok := certs[vcek.TCB.Uint64()]
 	if !ok {
 		return nil, fmt.Errorf("no certificate found at %q (host present, bad TCB %v)", url, vcek.TCB)
 	}

--- a/testing/fakekds.go
+++ b/testing/fakekds.go
@@ -187,7 +187,7 @@ func (f *FakeKDS) Get(url string) ([]byte, error) {
 	if certs == nil {
 		return nil, fmt.Errorf("no certificate found at %q (unknown HWID %v)", url, vcek.HWID)
 	}
-	certbytes, ok := certs[vcek.TCB]
+	certbytes, ok := certs[uint64(vcek.TCB)]
 	if !ok {
 		return nil, fmt.Errorf("no certificate found at %q (host present, bad TCB %v)", url, vcek.TCB)
 	}

--- a/tools/lib/report/report.go
+++ b/tools/lib/report/report.go
@@ -122,9 +122,9 @@ func asBin(report *spb.Attestation) ([]byte, error) {
 }
 
 func tcbBreakdown(tcb uint64) string {
-	parts := kds.DecomposeTCBVersion(kds.TCBVersion(tcb))
-	return fmt.Sprintf("0x%x:{ucode: %d, snp: %d, tee: %d, bl: %d}", tcb, parts.UcodeSpl, parts.SnpSpl,
-		parts.TeeSpl, parts.BlSpl)
+	v0 := kds.TCBVersionV0(tcb)
+	return fmt.Sprintf("0x%x:{ucode: %d, snp: %d, tee: %d, bl: %d}", tcb, v0.UcodeSpl(), v0.SnpSpl(),
+		v0.TeeSpl(), v0.BlSpl())
 }
 
 func tcbText(report *spb.Attestation) ([]byte, error) {

--- a/tools/lib/report/report.go
+++ b/tools/lib/report/report.go
@@ -122,9 +122,9 @@ func asBin(report *spb.Attestation) ([]byte, error) {
 }
 
 func tcbBreakdown(tcb uint64) string {
-	v0 := kds.TCBVersionV0(tcb)
-	return fmt.Sprintf("0x%x:{ucode: %d, snp: %d, tee: %d, bl: %d}", tcb, v0.UcodeSpl(), v0.SnpSpl(),
-		v0.TeeSpl(), v0.BlSpl())
+	v0 := kds.DecomposeTCBVersionV0(tcb)
+	return fmt.Sprintf("0x%x:{ucode: %d, snp: %d, tee: %d, bl: %d}", tcb, v0.UcodeSpl, v0.SnpSpl,
+		v0.TeeSpl, v0.BlSpl)
 }
 
 func tcbText(report *spb.Attestation) ([]byte, error) {

--- a/tools/lib/report/report_test.go
+++ b/tools/lib/report/report_test.go
@@ -230,4 +230,13 @@ func TestTransform(t *testing.T) {
 			t.Fatalf("Transform(_, \"textproto\") = %v, nil. Expect %v.", string(textout), string(input.textcerts))
 		}
 	})
+	t.Run("tcb", func(t *testing.T) {
+		tcbout, err := Transform(input.attestation, "tcb")
+		if err != nil {
+			t.Fatalf("Transform(_, \"tcb\") = _, %v. Expect nil.", err)
+		}
+		if len(tcbout) == 0 {
+			t.Fatalf("Transform(_, \"tcb\") returned empty output")
+		}
+	})
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -63,9 +63,9 @@ type Options struct {
 	MinimumVersion uint16
 	// MinimumTCB is the component-wise minimum TCB reported in the attestation report. This
 	// does not include the LaunchTCB.
-	MinimumTCB kds.TCBParts
+	MinimumTCB kds.TCBVersionV0
 	// MinimumLaunchTCB is the component-wise minimum for the attestation report LaunchTCB.
-	MinimumLaunchTCB kds.TCBParts
+	MinimumLaunchTCB kds.TCBVersionV0
 	// PermitProvisionalFirmware if true, allows the committed TCB, build, and API values to be less
 	// than or equal to the current values. If false, committed and current values must be equal.
 	PermitProvisionalFirmware bool
@@ -247,8 +247,8 @@ func PolicyToOptions(policy *cpb.Policy) (*Options, error) {
 		HostData:                  policy.GetHostData(),
 		ReportData:                policy.GetReportData(),
 		PlatformInfo:              platformInfo,
-		MinimumTCB:                kds.DecomposeTCBVersion(kds.TCBVersion(policy.GetMinimumTcb())),
-		MinimumLaunchTCB:          kds.DecomposeTCBVersion(kds.TCBVersion(policy.GetMinimumLaunchTcb())),
+		MinimumTCB:                kds.TCBVersionV0(policy.GetMinimumTcb()),
+		MinimumLaunchTCB:          kds.TCBVersionV0(policy.GetMinimumLaunchTcb()),
 		MinimumBuild:              uint8(policy.GetMinimumBuild()),
 		MinimumVersion:            minVersion,
 		RequireAuthorKey:          policy.GetRequireAuthorKey(),
@@ -348,8 +348,8 @@ func validateVerbatimFields(report *spb.Report, options *Options) error {
 // partDescription combines a TCB decomposition with a short description. It enables concise
 // comparisons with high quality error messages.
 type partDescription struct {
-	parts kds.TCBParts
-	desc  string
+	tcb  kds.TCBVersionV0
+	desc string
 }
 
 // reportTcbDescriptions is a collection of all TCB kinds that are within or about a report itself.
@@ -373,24 +373,24 @@ type reportTcbDescriptions struct {
 func getReportTcbs(report *spb.Report, certTcb kds.TCBVersion) *reportTcbDescriptions {
 	return &reportTcbDescriptions{
 		reported: partDescription{
-			parts: kds.DecomposeTCBVersion(kds.TCBVersion(report.GetReportedTcb())),
-			desc:  "report's REPORTED_TCB",
+			tcb:  kds.TCBVersionV0(report.GetReportedTcb()),
+			desc: "report's REPORTED_TCB",
 		},
 		current: partDescription{
-			parts: kds.DecomposeTCBVersion(kds.TCBVersion(report.GetCurrentTcb())),
-			desc:  "report's CURRENT_TCB",
+			tcb:  kds.TCBVersionV0(report.GetCurrentTcb()),
+			desc: "report's CURRENT_TCB",
 		},
 		committed: partDescription{
-			parts: kds.DecomposeTCBVersion(kds.TCBVersion(report.GetCommittedTcb())),
-			desc:  "report's COMMITTED_TCB",
+			tcb:  kds.TCBVersionV0(report.GetCommittedTcb()),
+			desc: "report's COMMITTED_TCB",
 		},
 		launch: partDescription{
-			parts: kds.DecomposeTCBVersion(kds.TCBVersion(report.GetLaunchTcb())),
-			desc:  "report's LAUNCH_TCB",
+			tcb:  kds.TCBVersionV0(report.GetLaunchTcb()),
+			desc: "report's LAUNCH_TCB",
 		},
 		cert: partDescription{
-			parts: kds.DecomposeTCBVersion(certTcb),
-			desc:  "TCB of the V[CL]EK certificate",
+			tcb:  kds.TCBVersionV0(certTcb),
+			desc: "TCB of the V[CL]EK certificate",
 		},
 	}
 }
@@ -406,34 +406,49 @@ type policyTcbDescriptions struct {
 func getPolicyTcbs(options *Options) *policyTcbDescriptions {
 	return &policyTcbDescriptions{
 		minimum: partDescription{
-			parts: options.MinimumTCB,
-			desc:  "policy minimum TCB",
+			tcb:  options.MinimumTCB,
+			desc: "policy minimum TCB",
 		},
 		minLaunch: partDescription{
-			parts: options.MinimumLaunchTCB,
-			desc:  "policy minimum launch TCB",
+			tcb:  options.MinimumLaunchTCB,
+			desc: "policy minimum launch TCB",
 		},
 	}
 }
 
 // tcbNeError return an error if the two TCBs are not equal
 func tcbNeError(left, right partDescription) error {
-	ltcb, _ := kds.ComposeTCBParts(left.parts)
-	rtcb, _ := kds.ComposeTCBParts(right.parts)
-	if ltcb == rtcb {
+	if left.tcb == right.tcb {
 		return nil
 	}
-	return fmt.Errorf("the %s 0x%x does not match the %s 0x%x", left.desc, ltcb, right.desc, rtcb)
+	return fmt.Errorf("the %s 0x%x does not match the %s 0x%x", left.desc, uint64(left.tcb), right.desc, uint64(right.tcb))
+}
+
+func formatTCBV0(t kds.TCBVersionV0) struct {
+	BlSpl, TeeSpl, Spl4, Spl5, Spl6, Spl7, SnpSpl, UcodeSpl uint8
+} {
+	return struct {
+		BlSpl, TeeSpl, Spl4, Spl5, Spl6, Spl7, SnpSpl, UcodeSpl uint8
+	}{
+		BlSpl:    t.BlSpl(),
+		TeeSpl:   t.TeeSpl(),
+		Spl4:     t.Spl4(),
+		Spl5:     t.Spl5(),
+		Spl6:     t.Spl6(),
+		Spl7:     t.Spl7(),
+		SnpSpl:   t.SnpSpl(),
+		UcodeSpl: t.UcodeSpl(),
+	}
 }
 
 // tcbGtError returns an error if wantLower is greater than (in part) wantHigher. It enforces
 // the property wantLower <= wantHigher.
 func tcbGtError(wantLower, wantHigher partDescription) error {
-	if kds.TCBPartsLE(wantLower.parts, wantHigher.parts) {
+	if wantLower.tcb.LE(wantHigher.tcb) {
 		return nil
 	}
 	return fmt.Errorf("the %s %+v is lower than the %s %+v in at least one component",
-		wantHigher.desc, wantHigher.parts, wantLower.desc, wantLower.parts)
+		wantHigher.desc, formatTCBV0(wantHigher.tcb), wantLower.desc, formatTCBV0(wantLower.tcb))
 }
 
 // validateTcb returns an error if the TCB values present in the report and V[CL]EK certificate do not

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -63,9 +63,9 @@ type Options struct {
 	MinimumVersion uint16
 	// MinimumTCB is the component-wise minimum TCB reported in the attestation report. This
 	// does not include the LaunchTCB.
-	MinimumTCB kds.TCBVersionV0
+	MinimumTCB kds.TCBVersion
 	// MinimumLaunchTCB is the component-wise minimum for the attestation report LaunchTCB.
-	MinimumLaunchTCB kds.TCBVersionV0
+	MinimumLaunchTCB kds.TCBVersion
 	// PermitProvisionalFirmware if true, allows the committed TCB, build, and API values to be less
 	// than or equal to the current values. If false, committed and current values must be equal.
 	PermitProvisionalFirmware bool
@@ -247,8 +247,8 @@ func PolicyToOptions(policy *cpb.Policy) (*Options, error) {
 		HostData:                  policy.GetHostData(),
 		ReportData:                policy.GetReportData(),
 		PlatformInfo:              platformInfo,
-		MinimumTCB:                kds.TCBVersionV0(policy.GetMinimumTcb()),
-		MinimumLaunchTCB:          kds.TCBVersionV0(policy.GetMinimumLaunchTcb()),
+		MinimumTCB:                kds.DecomposeTCBVersionV0(policy.GetMinimumTcb()),
+		MinimumLaunchTCB:          kds.DecomposeTCBVersionV0(policy.GetMinimumLaunchTcb()),
 		MinimumBuild:              uint8(policy.GetMinimumBuild()),
 		MinimumVersion:            minVersion,
 		RequireAuthorKey:          policy.GetRequireAuthorKey(),
@@ -348,7 +348,7 @@ func validateVerbatimFields(report *spb.Report, options *Options) error {
 // partDescription combines a TCB decomposition with a short description. It enables concise
 // comparisons with high quality error messages.
 type partDescription struct {
-	tcb  kds.TCBVersionV0
+	tcb  kds.TCBVersion
 	desc string
 }
 
@@ -373,23 +373,23 @@ type reportTcbDescriptions struct {
 func getReportTcbs(report *spb.Report, certTcb kds.TCBVersion) *reportTcbDescriptions {
 	return &reportTcbDescriptions{
 		reported: partDescription{
-			tcb:  kds.TCBVersionV0(report.GetReportedTcb()),
+			tcb:  kds.DecomposeTCBVersionV0(report.GetReportedTcb()),
 			desc: "report's REPORTED_TCB",
 		},
 		current: partDescription{
-			tcb:  kds.TCBVersionV0(report.GetCurrentTcb()),
+			tcb:  kds.DecomposeTCBVersionV0(report.GetCurrentTcb()),
 			desc: "report's CURRENT_TCB",
 		},
 		committed: partDescription{
-			tcb:  kds.TCBVersionV0(report.GetCommittedTcb()),
+			tcb:  kds.DecomposeTCBVersionV0(report.GetCommittedTcb()),
 			desc: "report's COMMITTED_TCB",
 		},
 		launch: partDescription{
-			tcb:  kds.TCBVersionV0(report.GetLaunchTcb()),
+			tcb:  kds.DecomposeTCBVersionV0(report.GetLaunchTcb()),
 			desc: "report's LAUNCH_TCB",
 		},
 		cert: partDescription{
-			tcb:  kds.TCBVersionV0(certTcb),
+			tcb:  certTcb,
 			desc: "TCB of the V[CL]EK certificate",
 		},
 	}
@@ -418,37 +418,26 @@ func getPolicyTcbs(options *Options) *policyTcbDescriptions {
 
 // tcbNeError return an error if the two TCBs are not equal
 func tcbNeError(left, right partDescription) error {
-	if left.tcb == right.tcb {
+	if left.tcb == nil || right.tcb == nil {
 		return nil
 	}
-	return fmt.Errorf("the %s 0x%x does not match the %s 0x%x", left.desc, uint64(left.tcb), right.desc, uint64(right.tcb))
-}
-
-func formatTCBV0(t kds.TCBVersionV0) struct {
-	BlSpl, TeeSpl, Spl4, Spl5, Spl6, Spl7, SnpSpl, UcodeSpl uint8
-} {
-	return struct {
-		BlSpl, TeeSpl, Spl4, Spl5, Spl6, Spl7, SnpSpl, UcodeSpl uint8
-	}{
-		BlSpl:    t.BlSpl(),
-		TeeSpl:   t.TeeSpl(),
-		Spl4:     t.Spl4(),
-		Spl5:     t.Spl5(),
-		Spl6:     t.Spl6(),
-		Spl7:     t.Spl7(),
-		SnpSpl:   t.SnpSpl(),
-		UcodeSpl: t.UcodeSpl(),
+	if left.tcb.StructVersion() == right.tcb.StructVersion() && left.tcb.Uint64() == right.tcb.Uint64() {
+		return nil
 	}
+	return fmt.Errorf("the %s 0x%x does not match the %s 0x%x", left.desc, left.tcb.Uint64(), right.desc, right.tcb.Uint64())
 }
 
 // tcbGtError returns an error if wantLower is greater than (in part) wantHigher. It enforces
 // the property wantLower <= wantHigher.
 func tcbGtError(wantLower, wantHigher partDescription) error {
+	if wantLower.tcb == nil || wantHigher.tcb == nil {
+		return nil
+	}
 	if wantLower.tcb.LE(wantHigher.tcb) {
 		return nil
 	}
-	return fmt.Errorf("the %s %+v is lower than the %s %+v in at least one component",
-		wantHigher.desc, formatTCBV0(wantHigher.tcb), wantLower.desc, formatTCBV0(wantLower.tcb))
+	return fmt.Errorf("the %s %s is lower than the %s %s in at least one component",
+		wantHigher.desc, wantHigher.tcb.String(), wantLower.desc, wantLower.tcb.String())
 }
 
 // validateTcb returns an error if the TCB values present in the report and V[CL]EK certificate do not

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -58,7 +58,12 @@ func TestValidateSnpAttestation(t *testing.T) {
 	reportID := []byte{0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	reportIDMA := []byte{0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	chipID := [64]byte{0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
-	goodtcb, _ := kds.ComposeTCBVersionV0(0x1f, 0x7f, 0, 0, 0, 0, 0x70, 0x92)
+	goodtcb := kds.TCBVersionV0{
+		BlSpl:    0x1f,
+		TeeSpl:   0x7f,
+		SnpSpl:   0x70,
+		UcodeSpl: 0x92,
+	}
 	type testOptions struct {
 		currentTcb     kds.TCBVersionV0
 		reportedTcb    kds.TCBVersionV0
@@ -73,10 +78,10 @@ func TestValidateSnpAttestation(t *testing.T) {
 		committedMinor uint8
 	}
 	makeReport := func(reportData [64]byte, opts testOptions) [labi.SnpReportRespReportSize]byte {
-		currentTcb := uint64(opts.currentTcb)
-		reportedTcb := uint64(opts.reportedTcb)
-		committedTcb := uint64(opts.committedTcb)
-		launchTcb := uint64(opts.launchTcb)
+		currentTcb := opts.currentTcb.Uint64()
+		reportedTcb := opts.reportedTcb.Uint64()
+		committedTcb := opts.committedTcb.Uint64()
+		launchTcb := opts.launchTcb.Uint64()
 		reportpb := &spb.Report{
 			Version:         snpReportVersion,
 			Policy:          debugPolicy,
@@ -214,9 +219,13 @@ func TestValidateSnpAttestation(t *testing.T) {
 			Input: noncecb1455,
 			Output: func() [labi.SnpReportRespReportSize]byte {
 				opts := baseOpts
-				tcb, _ := kds.ComposeTCBVersionV0(0, 0x7f, 0, 0, 0, 0, 0x70, 0x92)
-				opts.committedTcb = tcb
-				opts.launchTcb = tcb
+				opts.committedTcb = kds.TCBVersionV0{
+					BlSpl:    0,
+					TeeSpl:   0x7f,
+					SnpSpl:   0x70,
+					UcodeSpl: 0x92,
+				}
+				opts.launchTcb = opts.committedTcb
 				return makeReport(noncecb1455, opts)
 			}(),
 		},
@@ -238,7 +247,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 	getter := test.SimpleGetter(
 		map[string][]byte{
 			"https://kdsintf.amd.com/vcek/v1/Milan/cert_chain": rootBytes,
-			"https://kdsintf.amd.com/vcek/v1/Milan/0a0b0c0d0e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010203040506?blSPL=31&teeSPL=127&snpSPL=112&ucodeSPL=146": sign.Vcek.Raw,
+			"https://kdsintf.amd.com/vcek/v1/Milan/0a0b0c0d0e0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000010203040506?blSPL=31&snpSPL=112&teeSPL=127&ucodeSPL=146": sign.Vcek.Raw,
 		},
 	)
 	attestationFn := func(nonce [64]byte) *spb.Attestation {
@@ -303,7 +312,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 				ReportIDMA:             reportIDMA,
 				MinimumBuild:           2,
 				MinimumVersion:         uint16((1 << 8) | 49),
-				MinimumTCB:             kds.TCBVersionV0(0x02 | (uint64(0x05) << 48) | (uint64(0x44) << 56)),
+				MinimumTCB:             kds.DecomposeTCBVersionV0(0x02 | (uint64(0x05) << 48) | (uint64(0x44) << 56)),
 				TrustedAuthorKeyHashes: [][]byte{authorKeyDigest},
 			},
 		},
@@ -314,7 +323,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 				ReportData:   nonce12345[:],
 				GuestPolicy:  abi.SnpPolicy{Debug: true, SMT: true},
 				PlatformInfo: &abi.SnpPlatformInfo{SMTEnabled: true},
-				MinimumTCB:   kds.TCBVersionV0(0x02 | (uint64(0x05) << 48) | (uint64(0xff) << 56)),
+				MinimumTCB:   kds.DecomposeTCBVersionV0(0x02 | (uint64(0x05) << 48) | (uint64(0xff) << 56)),
 			},
 			wantErr: "the report's REPORTED_TCB {BlSpl:31 TeeSpl:127 Spl4:0 Spl5:0 Spl6:0 Spl7:0 SnpSpl:112 UcodeSpl:146} is lower than the policy minimum TCB {BlSpl:2 TeeSpl:0 Spl4:0 Spl5:0 Spl6:0 Spl7:0 SnpSpl:5 UcodeSpl:255} in at least one component",
 		},

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/google/go-sev-guest/kds"
 	test "github.com/google/go-sev-guest/testing"
 	"github.com/google/go-sev-guest/verify"
-	"go.uber.org/multierr"
 	"google.golang.org/protobuf/encoding/prototext"
 
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
@@ -59,17 +58,12 @@ func TestValidateSnpAttestation(t *testing.T) {
 	reportID := []byte{0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	reportIDMA := []byte{0x00, 0x06, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}
 	chipID := [64]byte{0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06}
-	goodtcb := kds.TCBParts{
-		BlSpl:    0x1f,
-		TeeSpl:   0x7f,
-		SnpSpl:   0x70,
-		UcodeSpl: 0x92,
-	}
+	goodtcb, _ := kds.ComposeTCBVersionV0(0x1f, 0x7f, 0, 0, 0, 0, 0x70, 0x92)
 	type testOptions struct {
-		currentTcb     kds.TCBParts
-		reportedTcb    kds.TCBParts
-		committedTcb   kds.TCBParts
-		launchTcb      kds.TCBParts
+		currentTcb     kds.TCBVersionV0
+		reportedTcb    kds.TCBVersionV0
+		committedTcb   kds.TCBVersionV0
+		launchTcb      kds.TCBVersionV0
 		signerInfo     abi.SignerInfo
 		currentBuild   uint8
 		currentMajor   uint8
@@ -79,16 +73,10 @@ func TestValidateSnpAttestation(t *testing.T) {
 		committedMinor uint8
 	}
 	makeReport := func(reportData [64]byte, opts testOptions) [labi.SnpReportRespReportSize]byte {
-		currentTcb, currerr := kds.ComposeTCBParts(opts.currentTcb)
-		reportedTcb, reportederr := kds.ComposeTCBParts(opts.reportedTcb)
-		committedTcb, committederr := kds.ComposeTCBParts(opts.committedTcb)
-		launchTcb, launcherr := kds.ComposeTCBParts(opts.launchTcb)
-		if err := multierr.Combine(currerr,
-			reportederr,
-			committederr,
-			launcherr); err != nil {
-			t.Fatal(err)
-		}
+		currentTcb := uint64(opts.currentTcb)
+		reportedTcb := uint64(opts.reportedTcb)
+		committedTcb := uint64(opts.committedTcb)
+		launchTcb := uint64(opts.launchTcb)
 		reportpb := &spb.Report{
 			Version:         snpReportVersion,
 			Policy:          debugPolicy,
@@ -142,7 +130,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 		VcekCreationTime: now,
 		VlekCreationTime: now,
 		VcekCustom: test.CertOverride{
-			Extensions: test.CustomExtensions(
+			Extensions: test.CustomExtensionsV0(
 				goodtcb,
 				chipID[:],
 				"",
@@ -150,7 +138,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			),
 		},
 		VlekCustom: test.CertOverride{
-			Extensions: test.CustomExtensions(
+			Extensions: test.CustomExtensionsV0(
 				goodtcb,
 				nil,
 				"Cloud Service Provider",
@@ -226,8 +214,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 			Input: noncecb1455,
 			Output: func() [labi.SnpReportRespReportSize]byte {
 				opts := baseOpts
-				tcb := goodtcb
-				tcb.BlSpl = 0
+				tcb, _ := kds.ComposeTCBVersionV0(0, 0x7f, 0, 0, 0, 0, 0x70, 0x92)
 				opts.committedTcb = tcb
 				opts.launchTcb = tcb
 				return makeReport(noncecb1455, opts)
@@ -316,7 +303,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 				ReportIDMA:             reportIDMA,
 				MinimumBuild:           2,
 				MinimumVersion:         uint16((1 << 8) | 49),
-				MinimumTCB:             kds.TCBParts{UcodeSpl: 0x44, SnpSpl: 0x05, BlSpl: 0x02},
+				MinimumTCB:             kds.TCBVersionV0(0x02 | (uint64(0x05) << 48) | (uint64(0x44) << 56)),
 				TrustedAuthorKeyHashes: [][]byte{authorKeyDigest},
 			},
 		},
@@ -327,7 +314,7 @@ func TestValidateSnpAttestation(t *testing.T) {
 				ReportData:   nonce12345[:],
 				GuestPolicy:  abi.SnpPolicy{Debug: true, SMT: true},
 				PlatformInfo: &abi.SnpPlatformInfo{SMTEnabled: true},
-				MinimumTCB:   kds.TCBParts{UcodeSpl: 0xff, SnpSpl: 0x05, BlSpl: 0x02},
+				MinimumTCB:   kds.TCBVersionV0(0x02 | (uint64(0x05) << 48) | (uint64(0xff) << 56)),
 			},
 			wantErr: "the report's REPORTED_TCB {BlSpl:31 TeeSpl:127 Spl4:0 Spl5:0 Spl6:0 Spl7:0 SnpSpl:112 UcodeSpl:146} is lower than the policy minimum TCB {BlSpl:2 TeeSpl:0 Spl4:0 Spl5:0 Spl6:0 Spl7:0 SnpSpl:5 UcodeSpl:255} in at least one component",
 		},
@@ -477,10 +464,12 @@ func TestValidateSnpAttestation(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		if err := SnpAttestation(tc.attestation, tc.opts); (err == nil && tc.wantErr != "") ||
-			(err != nil && (tc.wantErr == "" || !strings.Contains(err.Error(), tc.wantErr))) {
-			t.Errorf("%s: SnpAttestation(%v) errored unexpectedly. Got '%v', want '%s'", tc.name, tc.attestation, err, tc.wantErr)
-		}
+		t.Run(tc.name, func(t *testing.T) {
+			if err := SnpAttestation(tc.attestation, tc.opts); (err == nil && tc.wantErr != "") ||
+				(err != nil && (tc.wantErr == "" || !strings.Contains(err.Error(), tc.wantErr))) {
+				t.Errorf("Got err '%v', want error containing '%s'", err, tc.wantErr)
+			}
+		})
 	}
 }
 

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -810,7 +810,7 @@ func fillInAttestation(ctx context.Context, attestation *spb.Attestation, option
 	switch info.SigningKey {
 	case abi.VcekReportSigner:
 		if len(chain.GetVcekCert()) == 0 {
-			vcekURL := kds.VCEKCertURL(productLine, report.GetChipId(), kds.TCBVersionV0(report.GetReportedTcb()))
+			vcekURL := kds.VCEKCertURL(productLine, report.GetChipId(), kds.DecomposeTCBVersionV0(report.GetReportedTcb()))
 			vcek, err := trust.GetWith(ctx, getter, vcekURL)
 			if err != nil {
 				return &trust.AttestationRecreationErr{

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -810,7 +810,7 @@ func fillInAttestation(ctx context.Context, attestation *spb.Attestation, option
 	switch info.SigningKey {
 	case abi.VcekReportSigner:
 		if len(chain.GetVcekCert()) == 0 {
-			vcekURL := kds.VCEKCertURL(productLine, report.GetChipId(), kds.TCBVersion(report.GetReportedTcb()))
+			vcekURL := kds.VCEKCertURL(productLine, report.GetChipId(), kds.TCBVersionV0(report.GetReportedTcb()))
 			vcek, err := trust.GetWith(ctx, getter, vcekURL)
 			if err != nil {
 				return &trust.AttestationRecreationErr{

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -790,7 +790,7 @@ func TestRealAttestationVerification(t *testing.T) {
 		map[string][]byte{
 			"https://kdsintf.amd.com/vcek/v1/Milan/cert_chain": trust.AskArkMilanVcekBytes,
 			// Use the VCEK's hwID and known TCB values to specify the URL its VCEK cert would be fetched from.
-			"https://kdsintf.amd.com/vcek/v1/Milan/3ac3fe21e13fb0990eb28a802e3fb6a29483a6b0753590c951bdd3b8e53786184ca39e359669a2b76a1936776b564ea464cdce40c05f63c9b610c5068b006b5d?blSPL=2&teeSPL=0&snpSPL=5&ucodeSPL=68": testdata.VcekBytes,
+			"https://kdsintf.amd.com/vcek/v1/Milan/3ac3fe21e13fb0990eb28a802e3fb6a29483a6b0753590c951bdd3b8e53786184ca39e359669a2b76a1936776b564ea464cdce40c05f63c9b610c5068b006b5d?blSPL=2&snpSPL=5&teeSPL=0&ucodeSPL=68": testdata.VcekBytes,
 		},
 	)
 	tcs := []struct {
@@ -867,9 +867,9 @@ func TestV3KDSProduct(t *testing.T) {
 		t.Fatalf("no test cases")
 	}
 	getter := test.SimpleGetter(map[string][]byte{
-		"https://kdsintf.amd.com/vcek/v1/Milan/00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000?blSPL=0&teeSPL=0&snpSPL=0&ucodeSPL=0": []byte("milancert"),
+		"https://kdsintf.amd.com/vcek/v1/Milan/00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000?blSPL=0&snpSPL=0&teeSPL=0&ucodeSPL=0": []byte("milancert"),
 		"https://kdsintf.amd.com/vcek/v1/Milan/cert_chain": trust.AskArkMilanVcekBytes,
-		"https://kdsintf.amd.com/vcek/v1/Genoa/00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000?blSPL=0&teeSPL=0&snpSPL=0&ucodeSPL=0": []byte("genoacert"),
+		"https://kdsintf.amd.com/vcek/v1/Genoa/00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000?blSPL=0&snpSPL=0&teeSPL=0&ucodeSPL=0": []byte("genoacert"),
 		"https://kdsintf.amd.com/vcek/v1/Genoa/cert_chain": trust.AskArkGenoaVcekBytes,
 	})
 	options := &Options{


### PR DESCRIPTION
## Overview

Refactor platform security patch level representation for StructVersion 0 (Milan, Genoa, Siena) onto an explicit `TCBVersionV0` type backed directly by `uint64`.

## Why

The `TCBParts` struct attempted to represent TCB registers as a single monolithic struct. However, AMD Specification #57230 defines distinct 8-byte hardware wire format layouts across processor generations:
- **StructVersion 0** (Family 19h): `[blSPL, teeSPL, spl_4..7, snpSPL, ucodeSPL]`
- **StructVersion 1** (Family 1Ah / Turin): `[fmcSPL, blSPL, teeSPL, snpSPL, spl_5..7, ucodeSPL]`

Reusing a single struct across processor generations cannot express version-specific hardware schemas, breaks ABI compatibility, and forces callers to rely on runtime checks, fallback heuristics, and intermediate struct conversions.

Establishing `TCBVersionV0` as an explicit, packed integer type provides type-safe field accessors and component-wise comparisons without intermediate struct allocations, creating a clean baseline before introducing StructVersion 1 (Turin) support.

### Long-Term Interface Plan

As `TCBVersionV1` is introduced for Family 1Ah, a common `TCBVersion` interface will unify common accessors across versions (`BlSpl()`, `TeeSpl()`, `SnpSpl()`, `UcodeSpl()`). Version-specific fields (`FmcSpl()` on V1, `Spl4()` on V0) will remain on their concrete types, accessible via type assertions/switches to ensure compile-time type safety without returning silent defaults.