### PR TITLE
abi: add Turin CPUID matching and define TurinSiliconIDSize

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -61,8 +61,12 @@ const (
 	ReportIDSize = 32
 	// ReportIDMASize is the field size of REPORT_ID_MA in an SEV-SNP attestation report.
 	ReportIDMASize = 32
-	// ChipIDSize is the field size of CHIP_ID in an SEV-SNP attestation report.
+	// ChipIDSize is the field size of CHIP_ID in an SEV-SNP attestation report
+	// (AMD Publication #56860 Table 23).
 	ChipIDSize = 64
+	// TurinSiliconIDSize is the field size of the Silicon ID in an SEV-SNP attestation
+	// report on Family 1Ah (Turin) processors (AMD Publication #56860 Table 23).
+	TurinSiliconIDSize = 8
 	// SignatureSize is the field size of SIGNATURE in an SEV-SNP attestation report.
 	SignatureSize = 512
 
@@ -1038,8 +1042,10 @@ func SevProductFromCpuid1Eax(eax uint32) *pb.SevProduct {
 			unknown()
 		}
 	case zen5Family:
-		switch model {
-		case turinModel:
+		// Table 4 of https://www.amd.com/system/files/TechDocs/57230.pdf defines Turin as
+		// Family 1Ah with Extended Model 0h or 1h. Shifting model >> 4 yields Extended Model.
+		switch model >> 4 {
+		case 0, 1:
 			productName = pb.SevProduct_SEV_PRODUCT_TURIN
 		default:
 			unknown()

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -439,6 +439,44 @@ func TestSevProduct(t *testing.T) {
 				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
 			},
 		},
+		{
+			eax: 0x00b10f20,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			eax: 0x00b10f21,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
+			},
+		},
+		{
+			// Turin with base model 0 (0x00b00f00)
+			eax: 0x00b00f00,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			// Turin Dense / Zen 5c with base model 1 (0x00b10f10)
+			eax: 0x00b10f10,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			// Zen 5 Family 1Ah with Extended Model 2 (unmapped) -> Unknown
+			eax: 0x00b20f00,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_UNKNOWN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("EAX_0x%x", tc.eax), func(t *testing.T) {


### PR DESCRIPTION
Add CPUID Family 1Ah models 0h and 1h (Turin and Turin Dense) to `SevProductFromCpuid1Eax` per AMD Publication #57230 Table 4.

Define `TurinSiliconIDSize = 8` to represent the 8-byte Silicon ID prefix within the 64-byte `CHIP_ID` field in an SEV-SNP attestation report on Family 1Ah processors, per AMD Publication #56860 Table 23. The `CHIP_ID` field size remains `ChipIDSize = 64` across all generations.