### PR TITLE
kds: add TCBVersionV1 and TCB parsing for Turin

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -61,8 +61,12 @@ const (
 	ReportIDSize = 32
 	// ReportIDMASize is the field size of REPORT_ID_MA in an SEV-SNP attestation report.
 	ReportIDMASize = 32
-	// ChipIDSize is the field size of CHIP_ID in an SEV-SNP attestation report.
+	// ChipIDSize is the field size of CHIP_ID in an SEV-SNP attestation report
+	// (AMD Publication #56860 Table 23).
 	ChipIDSize = 64
+	// TurinSiliconIDSize is the field size of the Silicon ID in an SEV-SNP attestation
+	// report on Family 1Ah (Turin) processors (AMD Publication #56860 Table 23).
+	TurinSiliconIDSize = 8
 	// SignatureSize is the field size of SIGNATURE in an SEV-SNP attestation report.
 	SignatureSize = 512
 
@@ -1038,8 +1042,10 @@ func SevProductFromCpuid1Eax(eax uint32) *pb.SevProduct {
 			unknown()
 		}
 	case zen5Family:
-		switch model {
-		case turinModel:
+		// Table 4 of https://www.amd.com/system/files/TechDocs/57230.pdf defines Turin as
+		// Family 1Ah with Extended Model 0h or 1h. Shifting model >> 4 yields Extended Model.
+		switch model >> 4 {
+		case 0, 1:
 			productName = pb.SevProduct_SEV_PRODUCT_TURIN
 		default:
 			unknown()

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -439,6 +439,44 @@ func TestSevProduct(t *testing.T) {
 				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
 			},
 		},
+		{
+			eax: 0x00b10f20,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			eax: 0x00b10f21,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
+			},
+		},
+		{
+			// Turin with base model 0 (0x00b00f00)
+			eax: 0x00b00f00,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			// Turin Dense / Zen 5c with base model 1 (0x00b10f10)
+			eax: 0x00b10f10,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			// Zen 5 Family 1Ah with Extended Model 2 (unmapped) -> Unknown
+			eax: 0x00b20f00,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_UNKNOWN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("EAX_0x%x", tc.eax), func(t *testing.T) {

--- a/kds/kds.go
+++ b/kds/kds.go
@@ -281,10 +281,13 @@ func DecomposeTCBVersionV0(raw uint64) TCBVersionV0 {
 }
 
 // ParseTCBVersionV0 parses KDS REST query parameters into a TCBVersionV0.
+// Valid parameter value ranges are specified in AMD Publication #57230 Table 12
+// (Milan and Genoa REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
 func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 	var blSpl, teeSpl, snpSpl, ucodeSpl uint8
 	for key, valuelist := range values {
 		var setter func(number uint8)
+		// AMD Publication #57230 Table 12: blSPL, teeSPL, snpSPL are in the range 0..127.
 		maxVal := 127
 		switch key {
 		case "blSPL":
@@ -294,6 +297,7 @@ func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 		case "snpSPL":
 			setter = func(number uint8) { snpSpl = number }
 		case "ucodeSPL":
+			// AMD Publication #57230 Table 12: ucodeSPL is in the range 0..255.
 			maxVal = 255
 			setter = func(number uint8) { ucodeSpl = number }
 		default:
@@ -313,6 +317,174 @@ func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 		SnpSpl:   snpSpl,
 		UcodeSpl: ucodeSpl,
 	}, nil
+}
+
+// TCBVersionV1 represents the platform security patch levels for StructVersion 1 (Turin).
+type TCBVersionV1 struct {
+	// FmcSpl is the FMC security patch level.
+	FmcSpl uint8
+	// BlSpl is the bootloader security patch level.
+	BlSpl uint8
+	// TeeSpl is the TEE security patch level.
+	TeeSpl uint8
+	// SnpSpl is the SNP security patch level.
+	SnpSpl uint8
+	// Spl5 is reserved.
+	Spl5 uint8
+	// Spl6 is reserved.
+	Spl6 uint8
+	// Spl7 is reserved.
+	Spl7 uint8
+	// UcodeSpl is the microcode security patch level.
+	UcodeSpl uint8
+}
+
+// StructVersion returns 1 for Turin.
+func (t TCBVersionV1) StructVersion() uint8 { return 1 }
+
+// Uint64 returns the 64-bit wire representation of TCBVersionV1.
+func (t TCBVersionV1) Uint64() uint64 {
+	return (uint64(t.UcodeSpl) << 56) |
+		(uint64(t.Spl7) << 48) |
+		(uint64(t.Spl6) << 40) |
+		(uint64(t.Spl5) << 32) |
+		(uint64(t.SnpSpl) << 24) |
+		(uint64(t.TeeSpl) << 16) |
+		(uint64(t.BlSpl) << 8) |
+		(uint64(t.FmcSpl) << 0)
+}
+
+// Values encodes TCBVersionV1 into KDS REST URL query parameters.
+func (t TCBVersionV1) Values() url.Values {
+	values := make(url.Values)
+	values.Set("fmcSPL", fmt.Sprintf("%d", t.FmcSpl))
+	values.Set("blSPL", fmt.Sprintf("%d", t.BlSpl))
+	values.Set("teeSPL", fmt.Sprintf("%d", t.TeeSpl))
+	values.Set("snpSPL", fmt.Sprintf("%d", t.SnpSpl))
+	values.Set("ucodeSPL", fmt.Sprintf("%d", t.UcodeSpl))
+	return values
+}
+
+// LE returns true iff all TCB components of t are <= the corresponding components of other.
+func (t TCBVersionV1) LE(other TCBVersion) bool {
+	o, ok := other.(TCBVersionV1)
+	if !ok {
+		return false
+	}
+	return t.UcodeSpl <= o.UcodeSpl &&
+		t.Spl7 <= o.Spl7 &&
+		t.Spl6 <= o.Spl6 &&
+		t.Spl5 <= o.Spl5 &&
+		t.SnpSpl <= o.SnpSpl &&
+		t.TeeSpl <= o.TeeSpl &&
+		t.BlSpl <= o.BlSpl &&
+		t.FmcSpl <= o.FmcSpl
+}
+
+func (t TCBVersionV1) String() string {
+	return fmt.Sprintf("{FmcSpl:%d BlSpl:%d TeeSpl:%d SnpSpl:%d Spl5:%d Spl6:%d Spl7:%d UcodeSpl:%d}",
+		t.FmcSpl, t.BlSpl, t.TeeSpl, t.SnpSpl, t.Spl5, t.Spl6, t.Spl7, t.UcodeSpl)
+}
+
+// DecomposeTCBVersionV1 decomposes a 64-bit raw TCB integer into a TCBVersionV1.
+func DecomposeTCBVersionV1(raw uint64) TCBVersionV1 {
+	return TCBVersionV1{
+		FmcSpl:   uint8(raw & 0xff),
+		BlSpl:    uint8((raw >> 8) & 0xff),
+		TeeSpl:   uint8((raw >> 16) & 0xff),
+		SnpSpl:   uint8((raw >> 24) & 0xff),
+		Spl5:     uint8((raw >> 32) & 0xff),
+		Spl6:     uint8((raw >> 40) & 0xff),
+		Spl7:     uint8((raw >> 48) & 0xff),
+		UcodeSpl: uint8((raw >> 56) & 0xff),
+	}
+}
+
+// ParseTCBVersionV1 parses KDS REST query parameters into a TCBVersionV1.
+// Valid parameter value ranges are specified in AMD Publication #57230 Table 13
+// (Turin REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
+func ParseTCBVersionV1(values url.Values) (TCBVersionV1, error) {
+	var fmcSpl, blSpl, teeSpl, snpSpl, ucodeSpl uint8
+	for key, valuelist := range values {
+		var setter func(number uint8)
+		// AMD Publication #57230 Table 13: fmcSPL, blSPL, teeSPL, snpSPL are in the range 0..127.
+		maxVal := 127
+		switch key {
+		case "fmcSPL":
+			setter = func(number uint8) { fmcSpl = number }
+		case "blSPL":
+			setter = func(number uint8) { blSpl = number }
+		case "teeSPL":
+			setter = func(number uint8) { teeSpl = number }
+		case "snpSPL":
+			setter = func(number uint8) { snpSpl = number }
+		case "ucodeSPL":
+			// AMD Publication #57230 Table 13: ucodeSPL is in the range 0..255.
+			maxVal = 255
+			setter = func(number uint8) { ucodeSpl = number }
+		default:
+			return TCBVersionV1{}, fmt.Errorf("unexpected KDS TCB version URL argument %q", key)
+		}
+		for _, val := range valuelist {
+			number, err := strconv.Atoi(val)
+			if err != nil || number < 0 || number > maxVal {
+				return TCBVersionV1{}, fmt.Errorf("invalid KDS TCB version URL argument value %q, want a value 0-%d", val, maxVal)
+			}
+			setter(uint8(number))
+		}
+	}
+	return TCBVersionV1{
+		FmcSpl:   fmcSpl,
+		BlSpl:    blSpl,
+		TeeSpl:   teeSpl,
+		SnpSpl:   snpSpl,
+		UcodeSpl: ucodeSpl,
+	}, nil
+}
+
+// DecomposeTCBVersion decomposes a raw 64-bit TCB integer into a TCBVersion for the given structVersion.
+func DecomposeTCBVersion(structVersion uint8, raw uint64) (TCBVersion, error) {
+	switch structVersion {
+	case 0:
+		return DecomposeTCBVersionV0(raw), nil
+	case 1:
+		return DecomposeTCBVersionV1(raw), nil
+	default:
+		return nil, fmt.Errorf("unsupported TCB structVersion: %d", structVersion)
+	}
+}
+
+// ParseTCBVersion parses query parameters into a TCBVersion based on structVersion.
+func ParseTCBVersion(structVersion uint8, values url.Values) (TCBVersion, error) {
+	switch structVersion {
+	case 0:
+		return ParseTCBVersionV0(values)
+	case 1:
+		return ParseTCBVersionV1(values)
+	default:
+		return nil, fmt.Errorf("unsupported TCB structVersion: %d", structVersion)
+	}
+}
+
+// StructVersionForProductLine returns the TCB StructVersion (0 or 1) for a given productLine.
+func StructVersionForProductLine(productLine string) (uint8, error) {
+	switch productLine {
+	case "Milan", "Genoa":
+		return 0, nil
+	case "Turin":
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("unknown product line: %q", productLine)
+	}
+}
+
+// DecomposeProductTCB decomposes a raw 64-bit TCB integer into a TCBVersion for the given productLine.
+func DecomposeProductTCB(productLine string, raw uint64) (TCBVersion, error) {
+	v, err := StructVersionForProductLine(productLine)
+	if err != nil {
+		return nil, err
+	}
+	return DecomposeTCBVersion(v, raw)
 }
 
 func asn1U8(ext *pkix.Extension, field string, out *uint8) error {

--- a/kds/kds_test.go
+++ b/kds/kds_test.go
@@ -394,3 +394,189 @@ func TestTCBVersionV0(t *testing.T) {
 		}
 	}
 }
+
+func TestTCBVersionV1(t *testing.T) {
+	tcb := TCBVersionV1{
+		FmcSpl:   1,
+		BlSpl:    2,
+		TeeSpl:   3,
+		SnpSpl:   4,
+		Spl5:     5,
+		Spl6:     6,
+		Spl7:     7,
+		UcodeSpl: 8,
+	}
+	if tcb.FmcSpl != 1 || tcb.BlSpl != 2 || tcb.TeeSpl != 3 || tcb.SnpSpl != 4 ||
+		tcb.Spl5 != 5 || tcb.Spl6 != 6 || tcb.Spl7 != 7 || tcb.UcodeSpl != 8 {
+		t.Errorf("TCBVersionV1 fields failed: got fmc=%d bl=%d tee=%d snp=%d spl5=%d spl6=%d spl7=%d ucode=%d",
+			tcb.FmcSpl, tcb.BlSpl, tcb.TeeSpl, tcb.SnpSpl, tcb.Spl5, tcb.Spl6, tcb.Spl7, tcb.UcodeSpl)
+	}
+	if tcb.StructVersion() != 1 {
+		t.Errorf("StructVersion() = %d, want 1", tcb.StructVersion())
+	}
+
+	raw := tcb.Uint64()
+	decomposed := DecomposeTCBVersionV1(raw)
+	if decomposed != tcb {
+		t.Errorf("DecomposeTCBVersionV1(0x%x) = %+v, want %+v", raw, decomposed, tcb)
+	}
+
+	vals := tcb.Values()
+	parsed, err := ParseTCBVersionV1(vals)
+	if err != nil {
+		t.Fatalf("ParseTCBVersionV1(%v) failed: %v", vals, err)
+	}
+	wantParsed := TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, UcodeSpl: 8}
+	if parsed != wantParsed {
+		t.Errorf("ParseTCBVersionV1(%v) = %+v, want %+v", vals, parsed, wantParsed)
+	}
+
+	base := TCBVersionV1{
+		FmcSpl:   10,
+		BlSpl:    10,
+		TeeSpl:   10,
+		SnpSpl:   10,
+		Spl5:     10,
+		Spl6:     10,
+		Spl7:     10,
+		UcodeSpl: 10,
+	}
+	if !base.LE(base) {
+		t.Errorf("expected base.LE(base) to be true")
+	}
+
+	higherFields := []struct {
+		name string
+		tcb  TCBVersionV1
+	}{
+		{"FmcSpl", TCBVersionV1{FmcSpl: 11, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"BlSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 11, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"TeeSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 11, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"SnpSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 11, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"Spl5", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 11, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"Spl6", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 11, Spl7: 10, UcodeSpl: 10}},
+		{"Spl7", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 11, UcodeSpl: 10}},
+		{"UcodeSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 11}},
+	}
+	for _, tc := range higherFields {
+		t.Run("LE_"+tc.name, func(t *testing.T) {
+			if !base.LE(tc.tcb) {
+				t.Errorf("expected base.LE(higher) to be true")
+			}
+			if tc.tcb.LE(base) {
+				t.Errorf("expected higher.LE(base) to be false")
+			}
+		})
+	}
+}
+
+func TestDecomposeTCBVersion(t *testing.T) {
+	tcs := []struct {
+		name          string
+		structVersion uint8
+		raw           uint64
+		want          TCBVersion
+		wantErr       bool
+	}{
+		{
+			name:          "StructVersion 0",
+			structVersion: 0,
+			raw:           0x0807060504030201,
+			want:          TCBVersionV0{BlSpl: 1, TeeSpl: 2, Spl4: 3, Spl5: 4, Spl6: 5, Spl7: 6, SnpSpl: 7, UcodeSpl: 8},
+		},
+		{
+			name:          "StructVersion 1",
+			structVersion: 1,
+			raw:           0x0807060504030201,
+			want:          TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, Spl5: 5, Spl6: 6, Spl7: 7, UcodeSpl: 8},
+		},
+		{
+			name:          "unsupported StructVersion",
+			structVersion: 2,
+			raw:           0,
+			wantErr:       true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecomposeTCBVersion(tc.structVersion, tc.raw)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("DecomposeTCBVersion(%d, 0x%x) error = %v, wantErr %v", tc.structVersion, tc.raw, err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("DecomposeTCBVersion(%d, 0x%x) = %+v, want %+v", tc.structVersion, tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseTCBVersion(t *testing.T) {
+	v0Vals := TCBVersionV0{BlSpl: 1, TeeSpl: 2, SnpSpl: 3, UcodeSpl: 4}.Values()
+	gotV0, err := ParseTCBVersion(0, v0Vals)
+	if err != nil {
+		t.Fatalf("ParseTCBVersion(0, %v) failed: %v", v0Vals, err)
+	}
+	wantV0 := TCBVersionV0{BlSpl: 1, TeeSpl: 2, SnpSpl: 3, UcodeSpl: 4}
+	if gotV0 != wantV0 {
+		t.Errorf("ParseTCBVersion(0, %v) = %+v, want %+v", v0Vals, gotV0, wantV0)
+	}
+
+	v1Vals := TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, UcodeSpl: 5}.Values()
+	gotV1, err := ParseTCBVersion(1, v1Vals)
+	if err != nil {
+		t.Fatalf("ParseTCBVersion(1, %v) failed: %v", v1Vals, err)
+	}
+	wantV1 := TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, UcodeSpl: 5}
+	if gotV1 != wantV1 {
+		t.Errorf("ParseTCBVersion(1, %v) = %+v, want %+v", v1Vals, gotV1, wantV1)
+	}
+
+	if _, err := ParseTCBVersion(2, v1Vals); err == nil {
+		t.Errorf("ParseTCBVersion(2, %v) expected error, got nil", v1Vals)
+	}
+}
+
+func TestStructVersionForProductLine(t *testing.T) {
+	tcs := []struct {
+		productLine string
+		want        uint8
+		wantErr     bool
+	}{
+		{"Milan", 0, false},
+		{"Genoa", 0, false},
+		{"Turin", 1, false},
+		{"Unknown", 0, true},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.productLine, func(t *testing.T) {
+			got, err := StructVersionForProductLine(tc.productLine)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("StructVersionForProductLine(%q) error = %v, wantErr %v", tc.productLine, err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("StructVersionForProductLine(%q) = %d, want %d", tc.productLine, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecomposeProductTCB(t *testing.T) {
+	raw := uint64(0x0807060504030201)
+	milanTCB, err := DecomposeProductTCB("Milan", raw)
+	if err != nil {
+		t.Fatalf("DecomposeProductTCB(Milan) failed: %v", err)
+	}
+	if milanTCB.StructVersion() != 0 {
+		t.Errorf("DecomposeProductTCB(Milan).StructVersion = %d, want 0", milanTCB.StructVersion())
+	}
+	turinTCB, err := DecomposeProductTCB("Turin", raw)
+	if err != nil {
+		t.Fatalf("DecomposeProductTCB(Turin) failed: %v", err)
+	}
+	if turinTCB.StructVersion() != 1 {
+		t.Errorf("DecomposeProductTCB(Turin).StructVersion = %d, want 1", turinTCB.StructVersion())
+	}
+	if _, err := DecomposeProductTCB("Unknown", raw); err == nil {
+		t.Errorf("DecomposeProductTCB(Unknown) expected error, got nil")
+	}
+}


### PR DESCRIPTION
Depends on #196.

Add `TCBVersionV1` representing the SEV-SNP Trusted Compute Base for AMD Family 1Ah (Turin) processors per AMD Publication #57230 Table 11 and Section 2.2 of the SEV-SNP Firmware ABI (#56860).

Add `DecomposeTCBVersionV1`, `ParseTCBVersionV1`, `DecomposeTCBVersion`, and `DecomposeProductTCB` to support both StructVersion-based and product-based TCB decomposition.