### PR TITLE
kds: add Turin VCEK URL generation and x509 extension parsing

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -61,8 +61,12 @@ const (
 	ReportIDSize = 32
 	// ReportIDMASize is the field size of REPORT_ID_MA in an SEV-SNP attestation report.
 	ReportIDMASize = 32
-	// ChipIDSize is the field size of CHIP_ID in an SEV-SNP attestation report.
+	// ChipIDSize is the field size of CHIP_ID in an SEV-SNP attestation report
+	// (AMD Publication #56860 Table 23).
 	ChipIDSize = 64
+	// TurinSiliconIDSize is the field size of the Silicon ID in an SEV-SNP attestation
+	// report on Family 1Ah (Turin) processors (AMD Publication #56860 Table 23).
+	TurinSiliconIDSize = 8
 	// SignatureSize is the field size of SIGNATURE in an SEV-SNP attestation report.
 	SignatureSize = 512
 
@@ -1038,8 +1042,10 @@ func SevProductFromCpuid1Eax(eax uint32) *pb.SevProduct {
 			unknown()
 		}
 	case zen5Family:
-		switch model {
-		case turinModel:
+		// Table 4 of https://www.amd.com/system/files/TechDocs/57230.pdf defines Turin as
+		// Family 1Ah with Extended Model 0h or 1h. Shifting model >> 4 yields Extended Model.
+		switch model >> 4 {
+		case 0, 1:
 			productName = pb.SevProduct_SEV_PRODUCT_TURIN
 		default:
 			unknown()

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -439,6 +439,44 @@ func TestSevProduct(t *testing.T) {
 				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
 			},
 		},
+		{
+			eax: 0x00b10f20,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			eax: 0x00b10f21,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
+			},
+		},
+		{
+			// Turin with base model 0 (0x00b00f00)
+			eax: 0x00b00f00,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			// Turin Dense / Zen 5c with base model 1 (0x00b10f10)
+			eax: 0x00b10f10,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			// Zen 5 Family 1Ah with Extended Model 2 (unmapped) -> Unknown
+			eax: 0x00b20f00,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_UNKNOWN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("EAX_0x%x", tc.eax), func(t *testing.T) {

--- a/kds/kds.go
+++ b/kds/kds.go
@@ -21,6 +21,7 @@ import (
 	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -59,6 +60,8 @@ var (
 	OidSpl7 = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 3704, 1, 3, 7})
 	// OidUcodeSpl is the x509v3 extension for V[CL]EK microcode security patch level.
 	OidUcodeSpl = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 3704, 1, 3, 8})
+	// OidFmcSpl is the x509v3 extension for FMC SPL (Zen 5 / Turin only).
+	OidFmcSpl = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 3704, 1, 3, 9})
 	// OidHwid is the x509v3 extension for VCEK certificate associated hardware identifier.
 	OidHwid = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 3704, 1, 4})
 	// OidCspID is the x509v3 extension for a VLEK certificate's Cloud Service Provider's
@@ -78,6 +81,7 @@ var (
 	kdsSpl6          = kdsOID{major: 3, minor: 6}
 	kdsSpl7          = kdsOID{major: 3, minor: 7}
 	kdsUcodeSpl      = kdsOID{major: 3, minor: 8}
+	kdsFmcSpl        = kdsOID{major: 3, minor: 9}
 	kdsHwid          = kdsOID{major: 4}
 	kdsCspID         = kdsOID{major: 5}
 
@@ -85,6 +89,13 @@ var (
 	kdsBaseURL  = "https://" + kdsHostname
 	kdsVcekPath = "/vcek/v1/"
 	kdsVlekPath = "/vlek/v1/"
+
+	// VcekHWIDStruct0Size is the HWID extension byte length in StructVersion 0 VCEK certificates
+	// (Family 19h: Milan, Genoa) per AMD Publication #57230 Table 10.
+	VcekHWIDStruct0Size = 64
+	// VcekHWIDStruct1Size is the HWID extension byte length in StructVersion 1 VCEK certificates
+	// (Family 1Ah: Turin) per AMD Publication #57230 Table 11.
+	VcekHWIDStruct1Size = 8
 
 	uint0 = &wrapperspb.UInt32Value{Value: 0}
 	uint1 = &wrapperspb.UInt32Value{Value: 1}
@@ -111,6 +122,7 @@ var (
 		0x00a00f10: "Milan",
 		0x00a10f10: "Genoa",
 		0x00b00f20: "Turin",
+		0x00b10f20: "Turin",
 	}
 )
 
@@ -134,8 +146,8 @@ type Extensions struct {
 	StructVersion uint8
 	ProductName   string
 	// The host driver knows the difference between primary and secondary HWID.
-	// Primary vs secondary is irrelevant to verification. Must be nil or
-	// abi.ChipIDSize long.
+	// Primary vs secondary is irrelevant to verification. Must be nil,
+	// VcekHWIDStruct0Size long (for StructVersion 0), or VcekHWIDStruct1Size long (for StructVersion 1).
 	HWID       []byte
 	TCBVersion TCBVersion
 	CspID      string
@@ -174,6 +186,9 @@ func oidTokdsOID(id asn1.ObjectIdentifier) (kdsOID, error) {
 	}
 	if id.Equal(OidUcodeSpl) {
 		return kdsUcodeSpl, nil
+	}
+	if id.Equal(OidFmcSpl) {
+		return kdsFmcSpl, nil
 	}
 	if id.Equal(OidCspID) {
 		return kdsCspID, nil
@@ -281,13 +296,10 @@ func DecomposeTCBVersionV0(raw uint64) TCBVersionV0 {
 }
 
 // ParseTCBVersionV0 parses KDS REST query parameters into a TCBVersionV0.
-// Valid parameter value ranges are specified in AMD Publication #57230 Table 12
-// (Milan and Genoa REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
 func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 	var blSpl, teeSpl, snpSpl, ucodeSpl uint8
 	for key, valuelist := range values {
 		var setter func(number uint8)
-		// AMD Publication #57230 Table 12: blSPL, teeSPL, snpSPL are in the range 0..127.
 		maxVal := 127
 		switch key {
 		case "blSPL":
@@ -297,7 +309,6 @@ func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 		case "snpSPL":
 			setter = func(number uint8) { snpSpl = number }
 		case "ucodeSPL":
-			// AMD Publication #57230 Table 12: ucodeSPL is in the range 0..255.
 			maxVal = 255
 			setter = func(number uint8) { ucodeSpl = number }
 		default:
@@ -401,13 +412,10 @@ func DecomposeTCBVersionV1(raw uint64) TCBVersionV1 {
 }
 
 // ParseTCBVersionV1 parses KDS REST query parameters into a TCBVersionV1.
-// Valid parameter value ranges are specified in AMD Publication #57230 Table 13
-// (Turin REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
 func ParseTCBVersionV1(values url.Values) (TCBVersionV1, error) {
 	var fmcSpl, blSpl, teeSpl, snpSpl, ucodeSpl uint8
 	for key, valuelist := range values {
 		var setter func(number uint8)
-		// AMD Publication #57230 Table 13: fmcSPL, blSPL, teeSPL, snpSPL are in the range 0..127.
 		maxVal := 127
 		switch key {
 		case "fmcSPL":
@@ -419,7 +427,6 @@ func ParseTCBVersionV1(values url.Values) (TCBVersionV1, error) {
 		case "snpSPL":
 			setter = func(number uint8) { snpSpl = number }
 		case "ucodeSPL":
-			// AMD Publication #57230 Table 13: ucodeSPL is in the range 0..255.
 			maxVal = 255
 			setter = func(number uint8) { ucodeSpl = number }
 		default:
@@ -485,6 +492,19 @@ func DecomposeProductTCB(productLine string, raw uint64) (TCBVersion, error) {
 		return nil, err
 	}
 	return DecomposeTCBVersion(v, raw)
+}
+
+// ParseProductTCBVersion parses query parameters into a TCBVersion based on productLine.
+func ParseProductTCBVersion(productLine string, values url.Values) (TCBVersion, error) {
+	v, err := StructVersionForProductLine(productLine)
+	if err != nil {
+		return nil, err
+	}
+	tcb, err := ParseTCBVersion(v, values)
+	if err != nil {
+		return nil, fmt.Errorf("%w for product line %q", err, productLine)
+	}
+	return tcb, nil
 }
 
 func asn1U8(ext *pkix.Extension, field string, out *uint8) error {
@@ -561,7 +581,16 @@ func kdsOidMapToExtensions(exts map[kdsOID]*pkix.Extension) (*Extensions, error)
 	}
 	hwidExt, ok := exts[kdsHwid]
 	if ok {
-		octet, err := asn1OctetString(hwidExt, "HWID", 64)
+		var expectedLen int
+		switch result.StructVersion {
+		case 0:
+			expectedLen = VcekHWIDStruct0Size
+		case 1:
+			expectedLen = VcekHWIDStruct1Size
+		default:
+			return nil, fmt.Errorf("unsupported structVersion %d", result.StructVersion)
+		}
+		octet, err := asn1OctetString(hwidExt, "HWID", expectedLen)
 		if err != nil {
 			return nil, err
 		}
@@ -586,9 +615,6 @@ func kdsOidMapToExtensions(exts map[kdsOID]*pkix.Extension) (*Extensions, error)
 	if err := asn1U8(exts[kdsSnpSpl], "SnpSpl", &snpspl); err != nil {
 		return nil, err
 	}
-	if err := asn1U8(exts[kdsSpl4], "Spl4", &spl4); err != nil {
-		return nil, err
-	}
 	if err := asn1U8(exts[kdsSpl5], "Spl5", &spl5); err != nil {
 		return nil, err
 	}
@@ -601,17 +627,47 @@ func kdsOidMapToExtensions(exts map[kdsOID]*pkix.Extension) (*Extensions, error)
 	if err := asn1U8(exts[kdsUcodeSpl], "UcodeSpl", &ucodespl); err != nil {
 		return nil, err
 	}
-	result.TCBVersion = TCBVersionV0{
-		BlSpl:    blspl,
-		TeeSpl:   teespl,
-		Spl4:     spl4,
-		Spl5:     spl5,
-		Spl6:     spl6,
-		Spl7:     spl7,
-		SnpSpl:   snpspl,
-		UcodeSpl: ucodespl,
+	switch result.StructVersion {
+	case 0:
+		if exts[kdsFmcSpl] != nil {
+			return nil, fmt.Errorf("unexpected fmcSPL extension for structVersion 0")
+		}
+		if err := asn1U8(exts[kdsSpl4], "Spl4", &spl4); err != nil {
+			return nil, err
+		}
+		result.TCBVersion = TCBVersionV0{
+			BlSpl:    blspl,
+			TeeSpl:   teespl,
+			Spl4:     spl4,
+			Spl5:     spl5,
+			Spl6:     spl6,
+			Spl7:     spl7,
+			SnpSpl:   snpspl,
+			UcodeSpl: ucodespl,
+		}
+		return &result, nil
+	case 1:
+		if exts[kdsSpl4] != nil {
+			return nil, fmt.Errorf("unexpected spl4 extension for structVersion 1")
+		}
+		var fmcspl uint8
+		if err := asn1U8(exts[kdsFmcSpl], "FmcSpl", &fmcspl); err != nil {
+			return nil, err
+		}
+		result.TCBVersion = TCBVersionV1{
+			FmcSpl:   fmcspl,
+			BlSpl:    blspl,
+			TeeSpl:   teespl,
+			SnpSpl:   snpspl,
+			Spl5:     spl5,
+			Spl6:     spl6,
+			Spl7:     spl7,
+			UcodeSpl: ucodespl,
+		}
+		return &result, nil
+	default:
+		return nil, fmt.Errorf("unsupported structVersion %d", result.StructVersion)
 	}
-	return &result, nil
 }
 
 // preEndorsementKeyCertificateExtensions returns the x509v3 extensions from the KDS specification interpreted
@@ -641,8 +697,17 @@ func VcekCertificateExtensions(cert *x509.Certificate) (*Extensions, error) {
 	if exts.CspID != "" {
 		return nil, fmt.Errorf("unexpected CSP_ID in VCEK certificate: %s", exts.CspID)
 	}
-	if len(exts.HWID) != abi.ChipIDSize {
-		return nil, fmt.Errorf("missing HWID extension for VCEK certificate")
+	var expectedHwidLen int
+	switch exts.StructVersion {
+	case 0:
+		expectedHwidLen = VcekHWIDStruct0Size
+	case 1:
+		expectedHwidLen = VcekHWIDStruct1Size
+	default:
+		return nil, fmt.Errorf("unsupported structVersion %d", exts.StructVersion)
+	}
+	if len(exts.HWID) != expectedHwidLen {
+		return nil, fmt.Errorf("VCEK certificate HWID expected %d bytes, got %d", expectedHwidLen, len(exts.HWID))
 	}
 	return exts, nil
 }
@@ -725,14 +790,59 @@ func ProductCertChainURL(s abi.ReportSigner, productLine string) string {
 	return fmt.Sprintf("%s/cert_chain", productBaseURL(s, productLine))
 }
 
+func validateProductTCB(product string, tcb TCBVersion) error {
+	if tcb == nil {
+		return errors.New("tcb cannot be nil")
+	}
+	expectedVersion, err := StructVersionForProductLine(product)
+	if err != nil {
+		return err
+	}
+	if tcb.StructVersion() != expectedVersion {
+		return fmt.Errorf("product %q requires TCB StructVersion %d, got %d", product, expectedVersion, tcb.StructVersion())
+	}
+	return nil
+}
+
 // VCEKCertURL returns the AMD KDS URL for retrieving the VCEK on a given product
-// at a given TCB version. The hwid is the CHIP_ID field in an attestation report.
-func VCEKCertURL(productLine string, hwid []byte, tcb TCBVersion) string {
+// at a given TCB version. The hwid may be either the raw silicon ID or the 64-byte
+// CHIP_ID field from an attestation report.
+//
+// Per AMD Publication #57230 Table 13, the KDS REST endpoint expects a hexadecimal
+// hwID string of:
+//   - 128 hex characters (VcekHWIDStruct0Size bytes) for Family 19h (Milan, Genoa, Siena)
+//   - 16 hex characters (VcekHWIDStruct1Size bytes) for Family 1Ah (Turin and later)
+//
+// If a 64-byte attestation report CHIP_ID (abi.ChipIDSize) is passed for Turin,
+// the first VcekHWIDStruct1Size bytes are used.
+func VCEKCertURL(productLine string, hwid []byte, tcb TCBVersion) (string, error) {
+	if err := validateProductTCB(productLine, tcb); err != nil {
+		return "", err
+	}
+	var hwidBytes []byte
+	switch productLine {
+	case "Milan", "Genoa":
+		if len(hwid) != VcekHWIDStruct0Size {
+			return "", fmt.Errorf("hwid has size %d, want %d", len(hwid), VcekHWIDStruct0Size)
+		}
+		hwidBytes = hwid
+	case "Turin":
+		switch len(hwid) {
+		case VcekHWIDStruct1Size:
+			hwidBytes = hwid
+		case abi.ChipIDSize:
+			hwidBytes = hwid[:VcekHWIDStruct1Size]
+		default:
+			return "", fmt.Errorf("hwid has size %d, want %d or %d", len(hwid), VcekHWIDStruct1Size, abi.ChipIDSize)
+		}
+	default:
+		return "", fmt.Errorf("unknown product line: %q", productLine)
+	}
 	return fmt.Sprintf("%s/%s?%s",
 		productBaseURL(abi.VcekReportSigner, productLine),
-		hex.EncodeToString(hwid),
+		hex.EncodeToString(hwidBytes),
 		tcb.Values().Encode(),
-	)
+	), nil
 }
 
 // VLEKCertURL returns the GET URL for retrieving a VLEK certificate, but without the necessary
@@ -846,12 +956,12 @@ func ParseProductCertChainURL(kdsurl string) (string, CertFunction, error) {
 	return parsed.productLine, parsed.function, nil
 }
 
-func parseTCBURL(u *url.URL) (TCBVersionV0, error) {
+func parseTCBURL(productLine string, u *url.URL) (TCBVersion, error) {
 	values, err := url.ParseQuery(u.RawQuery)
 	if err != nil {
-		return TCBVersionV0{}, fmt.Errorf("invalid AMD KDS URL query %q: %v", u.RawQuery, err)
+		return nil, fmt.Errorf("invalid AMD KDS URL query %q: %v", u.RawQuery, err)
 	}
-	return ParseTCBVersionV0(values)
+	return ParseProductTCBVersion(productLine, values)
 }
 
 // ParseVCEKCertURL returns the attestation report components represented in the given KDS VCEK
@@ -871,14 +981,25 @@ func ParseVCEKCertURL(kdsurl string) (VCEKCert, error) {
 	if err != nil {
 		return result, fmt.Errorf("hwid component of KDS URL is not a hex string: %q", parsed.simpleURL.Path)
 	}
-	if len(hwid) != abi.ChipIDSize {
-		return result, fmt.Errorf("hwid component of KDS URL has size %d, want %d", len(hwid), abi.ChipIDSize)
+	var expectedHwidLen int
+	switch parsed.productLine {
+	case "Milan", "Genoa":
+		expectedHwidLen = VcekHWIDStruct0Size
+	case "Turin":
+		expectedHwidLen = VcekHWIDStruct1Size
+	default:
+		return result, fmt.Errorf("unexpected product %q in VCEK URL", parsed.productLine)
 	}
-
+	if len(hwid) != expectedHwidLen {
+		return result, fmt.Errorf("unexpected HWID length %d for product %q, want %d", len(hwid), parsed.productLine, expectedHwidLen)
+	}
 	result.HWID = hwid
-
-	result.TCB, err = parseTCBURL(parsed.simpleURL)
-	return result, err
+	tcb, err := parseTCBURL(parsed.productLine, parsed.simpleURL)
+	if err != nil {
+		return result, err
+	}
+	result.TCB = tcb
+	return result, nil
 }
 
 // ParseVLEKCertURL returns the attestation report components represented in the given KDS VLEK
@@ -898,7 +1019,7 @@ func ParseVLEKCertURL(kdsurl string) (VLEKCert, error) {
 		return result, fmt.Errorf("vlek function is %q, want 'cert'", parsed.simpleURL.Path)
 	}
 
-	result.TCB, err = parseTCBURL(parsed.simpleURL)
+	result.TCB, err = parseTCBURL(parsed.productLine, parsed.simpleURL)
 	return result, err
 }
 

--- a/kds/kds.go
+++ b/kds/kds.go
@@ -281,10 +281,13 @@ func DecomposeTCBVersionV0(raw uint64) TCBVersionV0 {
 }
 
 // ParseTCBVersionV0 parses KDS REST query parameters into a TCBVersionV0.
+// Valid parameter value ranges are specified in AMD Publication #57230 Table 12
+// (Milan and Genoa REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
 func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 	var blSpl, teeSpl, snpSpl, ucodeSpl uint8
 	for key, valuelist := range values {
 		var setter func(number uint8)
+		// AMD Publication #57230 Table 12: blSPL, teeSPL, snpSPL are in the range 0..127.
 		maxVal := 127
 		switch key {
 		case "blSPL":
@@ -294,6 +297,7 @@ func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 		case "snpSPL":
 			setter = func(number uint8) { snpSpl = number }
 		case "ucodeSPL":
+			// AMD Publication #57230 Table 12: ucodeSPL is in the range 0..255.
 			maxVal = 255
 			setter = func(number uint8) { ucodeSpl = number }
 		default:
@@ -313,6 +317,174 @@ func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 		SnpSpl:   snpSpl,
 		UcodeSpl: ucodeSpl,
 	}, nil
+}
+
+// TCBVersionV1 represents the platform security patch levels for StructVersion 1 (Turin).
+type TCBVersionV1 struct {
+	// FmcSpl is the FMC security patch level.
+	FmcSpl uint8
+	// BlSpl is the bootloader security patch level.
+	BlSpl uint8
+	// TeeSpl is the TEE security patch level.
+	TeeSpl uint8
+	// SnpSpl is the SNP security patch level.
+	SnpSpl uint8
+	// Spl5 is reserved.
+	Spl5 uint8
+	// Spl6 is reserved.
+	Spl6 uint8
+	// Spl7 is reserved.
+	Spl7 uint8
+	// UcodeSpl is the microcode security patch level.
+	UcodeSpl uint8
+}
+
+// StructVersion returns 1 for Turin.
+func (t TCBVersionV1) StructVersion() uint8 { return 1 }
+
+// Uint64 returns the 64-bit wire representation of TCBVersionV1.
+func (t TCBVersionV1) Uint64() uint64 {
+	return (uint64(t.UcodeSpl) << 56) |
+		(uint64(t.Spl7) << 48) |
+		(uint64(t.Spl6) << 40) |
+		(uint64(t.Spl5) << 32) |
+		(uint64(t.SnpSpl) << 24) |
+		(uint64(t.TeeSpl) << 16) |
+		(uint64(t.BlSpl) << 8) |
+		(uint64(t.FmcSpl) << 0)
+}
+
+// Values encodes TCBVersionV1 into KDS REST URL query parameters.
+func (t TCBVersionV1) Values() url.Values {
+	values := make(url.Values)
+	values.Set("fmcSPL", fmt.Sprintf("%d", t.FmcSpl))
+	values.Set("blSPL", fmt.Sprintf("%d", t.BlSpl))
+	values.Set("teeSPL", fmt.Sprintf("%d", t.TeeSpl))
+	values.Set("snpSPL", fmt.Sprintf("%d", t.SnpSpl))
+	values.Set("ucodeSPL", fmt.Sprintf("%d", t.UcodeSpl))
+	return values
+}
+
+// LE returns true iff all TCB components of t are <= the corresponding components of other.
+func (t TCBVersionV1) LE(other TCBVersion) bool {
+	o, ok := other.(TCBVersionV1)
+	if !ok {
+		return false
+	}
+	return t.UcodeSpl <= o.UcodeSpl &&
+		t.Spl7 <= o.Spl7 &&
+		t.Spl6 <= o.Spl6 &&
+		t.Spl5 <= o.Spl5 &&
+		t.SnpSpl <= o.SnpSpl &&
+		t.TeeSpl <= o.TeeSpl &&
+		t.BlSpl <= o.BlSpl &&
+		t.FmcSpl <= o.FmcSpl
+}
+
+func (t TCBVersionV1) String() string {
+	return fmt.Sprintf("{FmcSpl:%d BlSpl:%d TeeSpl:%d SnpSpl:%d Spl5:%d Spl6:%d Spl7:%d UcodeSpl:%d}",
+		t.FmcSpl, t.BlSpl, t.TeeSpl, t.SnpSpl, t.Spl5, t.Spl6, t.Spl7, t.UcodeSpl)
+}
+
+// DecomposeTCBVersionV1 decomposes a 64-bit raw TCB integer into a TCBVersionV1.
+func DecomposeTCBVersionV1(raw uint64) TCBVersionV1 {
+	return TCBVersionV1{
+		FmcSpl:   uint8(raw & 0xff),
+		BlSpl:    uint8((raw >> 8) & 0xff),
+		TeeSpl:   uint8((raw >> 16) & 0xff),
+		SnpSpl:   uint8((raw >> 24) & 0xff),
+		Spl5:     uint8((raw >> 32) & 0xff),
+		Spl6:     uint8((raw >> 40) & 0xff),
+		Spl7:     uint8((raw >> 48) & 0xff),
+		UcodeSpl: uint8((raw >> 56) & 0xff),
+	}
+}
+
+// ParseTCBVersionV1 parses KDS REST query parameters into a TCBVersionV1.
+// Valid parameter value ranges are specified in AMD Publication #57230 Table 13
+// (Turin REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
+func ParseTCBVersionV1(values url.Values) (TCBVersionV1, error) {
+	var fmcSpl, blSpl, teeSpl, snpSpl, ucodeSpl uint8
+	for key, valuelist := range values {
+		var setter func(number uint8)
+		// AMD Publication #57230 Table 13: fmcSPL, blSPL, teeSPL, snpSPL are in the range 0..127.
+		maxVal := 127
+		switch key {
+		case "fmcSPL":
+			setter = func(number uint8) { fmcSpl = number }
+		case "blSPL":
+			setter = func(number uint8) { blSpl = number }
+		case "teeSPL":
+			setter = func(number uint8) { teeSpl = number }
+		case "snpSPL":
+			setter = func(number uint8) { snpSpl = number }
+		case "ucodeSPL":
+			// AMD Publication #57230 Table 13: ucodeSPL is in the range 0..255.
+			maxVal = 255
+			setter = func(number uint8) { ucodeSpl = number }
+		default:
+			return TCBVersionV1{}, fmt.Errorf("unexpected KDS TCB version URL argument %q", key)
+		}
+		for _, val := range valuelist {
+			number, err := strconv.Atoi(val)
+			if err != nil || number < 0 || number > maxVal {
+				return TCBVersionV1{}, fmt.Errorf("invalid KDS TCB version URL argument value %q, want a value 0-%d", val, maxVal)
+			}
+			setter(uint8(number))
+		}
+	}
+	return TCBVersionV1{
+		FmcSpl:   fmcSpl,
+		BlSpl:    blSpl,
+		TeeSpl:   teeSpl,
+		SnpSpl:   snpSpl,
+		UcodeSpl: ucodeSpl,
+	}, nil
+}
+
+// DecomposeTCBVersion decomposes a raw 64-bit TCB integer into a TCBVersion for the given structVersion.
+func DecomposeTCBVersion(structVersion uint8, raw uint64) (TCBVersion, error) {
+	switch structVersion {
+	case 0:
+		return DecomposeTCBVersionV0(raw), nil
+	case 1:
+		return DecomposeTCBVersionV1(raw), nil
+	default:
+		return nil, fmt.Errorf("unsupported TCB structVersion: %d", structVersion)
+	}
+}
+
+// ParseTCBVersion parses query parameters into a TCBVersion based on structVersion.
+func ParseTCBVersion(structVersion uint8, values url.Values) (TCBVersion, error) {
+	switch structVersion {
+	case 0:
+		return ParseTCBVersionV0(values)
+	case 1:
+		return ParseTCBVersionV1(values)
+	default:
+		return nil, fmt.Errorf("unsupported TCB structVersion: %d", structVersion)
+	}
+}
+
+// StructVersionForProductLine returns the TCB StructVersion (0 or 1) for a given productLine.
+func StructVersionForProductLine(productLine string) (uint8, error) {
+	switch productLine {
+	case "Milan", "Genoa":
+		return 0, nil
+	case "Turin":
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("unknown product line: %q", productLine)
+	}
+}
+
+// DecomposeProductTCB decomposes a raw 64-bit TCB integer into a TCBVersion for the given productLine.
+func DecomposeProductTCB(productLine string, raw uint64) (TCBVersion, error) {
+	v, err := StructVersionForProductLine(productLine)
+	if err != nil {
+		return nil, err
+	}
+	return DecomposeTCBVersion(v, raw)
 }
 
 func asn1U8(ext *pkix.Extension, field string, out *uint8) error {

--- a/kds/kds_test.go
+++ b/kds/kds_test.go
@@ -394,3 +394,189 @@ func TestTCBVersionV0(t *testing.T) {
 		}
 	}
 }
+
+func TestTCBVersionV1(t *testing.T) {
+	tcb := TCBVersionV1{
+		FmcSpl:   1,
+		BlSpl:    2,
+		TeeSpl:   3,
+		SnpSpl:   4,
+		Spl5:     5,
+		Spl6:     6,
+		Spl7:     7,
+		UcodeSpl: 8,
+	}
+	if tcb.FmcSpl != 1 || tcb.BlSpl != 2 || tcb.TeeSpl != 3 || tcb.SnpSpl != 4 ||
+		tcb.Spl5 != 5 || tcb.Spl6 != 6 || tcb.Spl7 != 7 || tcb.UcodeSpl != 8 {
+		t.Errorf("TCBVersionV1 fields failed: got fmc=%d bl=%d tee=%d snp=%d spl5=%d spl6=%d spl7=%d ucode=%d",
+			tcb.FmcSpl, tcb.BlSpl, tcb.TeeSpl, tcb.SnpSpl, tcb.Spl5, tcb.Spl6, tcb.Spl7, tcb.UcodeSpl)
+	}
+	if tcb.StructVersion() != 1 {
+		t.Errorf("StructVersion() = %d, want 1", tcb.StructVersion())
+	}
+
+	raw := tcb.Uint64()
+	decomposed := DecomposeTCBVersionV1(raw)
+	if decomposed != tcb {
+		t.Errorf("DecomposeTCBVersionV1(0x%x) = %+v, want %+v", raw, decomposed, tcb)
+	}
+
+	vals := tcb.Values()
+	parsed, err := ParseTCBVersionV1(vals)
+	if err != nil {
+		t.Fatalf("ParseTCBVersionV1(%v) failed: %v", vals, err)
+	}
+	wantParsed := TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, UcodeSpl: 8}
+	if parsed != wantParsed {
+		t.Errorf("ParseTCBVersionV1(%v) = %+v, want %+v", vals, parsed, wantParsed)
+	}
+
+	base := TCBVersionV1{
+		FmcSpl:   10,
+		BlSpl:    10,
+		TeeSpl:   10,
+		SnpSpl:   10,
+		Spl5:     10,
+		Spl6:     10,
+		Spl7:     10,
+		UcodeSpl: 10,
+	}
+	if !base.LE(base) {
+		t.Errorf("expected base.LE(base) to be true")
+	}
+
+	higherFields := []struct {
+		name string
+		tcb  TCBVersionV1
+	}{
+		{"FmcSpl", TCBVersionV1{FmcSpl: 11, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"BlSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 11, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"TeeSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 11, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"SnpSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 11, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"Spl5", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 11, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"Spl6", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 11, Spl7: 10, UcodeSpl: 10}},
+		{"Spl7", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 11, UcodeSpl: 10}},
+		{"UcodeSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 11}},
+	}
+	for _, tc := range higherFields {
+		t.Run("LE_"+tc.name, func(t *testing.T) {
+			if !base.LE(tc.tcb) {
+				t.Errorf("expected base.LE(higher) to be true")
+			}
+			if tc.tcb.LE(base) {
+				t.Errorf("expected higher.LE(base) to be false")
+			}
+		})
+	}
+}
+
+func TestDecomposeTCBVersion(t *testing.T) {
+	tcs := []struct {
+		name          string
+		structVersion uint8
+		raw           uint64
+		want          TCBVersion
+		wantErr       bool
+	}{
+		{
+			name:          "StructVersion 0",
+			structVersion: 0,
+			raw:           0x0807060504030201,
+			want:          TCBVersionV0{BlSpl: 1, TeeSpl: 2, Spl4: 3, Spl5: 4, Spl6: 5, Spl7: 6, SnpSpl: 7, UcodeSpl: 8},
+		},
+		{
+			name:          "StructVersion 1",
+			structVersion: 1,
+			raw:           0x0807060504030201,
+			want:          TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, Spl5: 5, Spl6: 6, Spl7: 7, UcodeSpl: 8},
+		},
+		{
+			name:          "unsupported StructVersion",
+			structVersion: 2,
+			raw:           0,
+			wantErr:       true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecomposeTCBVersion(tc.structVersion, tc.raw)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("DecomposeTCBVersion(%d, 0x%x) error = %v, wantErr %v", tc.structVersion, tc.raw, err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("DecomposeTCBVersion(%d, 0x%x) = %+v, want %+v", tc.structVersion, tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseTCBVersion(t *testing.T) {
+	v0Vals := TCBVersionV0{BlSpl: 1, TeeSpl: 2, SnpSpl: 3, UcodeSpl: 4}.Values()
+	gotV0, err := ParseTCBVersion(0, v0Vals)
+	if err != nil {
+		t.Fatalf("ParseTCBVersion(0, %v) failed: %v", v0Vals, err)
+	}
+	wantV0 := TCBVersionV0{BlSpl: 1, TeeSpl: 2, SnpSpl: 3, UcodeSpl: 4}
+	if gotV0 != wantV0 {
+		t.Errorf("ParseTCBVersion(0, %v) = %+v, want %+v", v0Vals, gotV0, wantV0)
+	}
+
+	v1Vals := TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, UcodeSpl: 5}.Values()
+	gotV1, err := ParseTCBVersion(1, v1Vals)
+	if err != nil {
+		t.Fatalf("ParseTCBVersion(1, %v) failed: %v", v1Vals, err)
+	}
+	wantV1 := TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, UcodeSpl: 5}
+	if gotV1 != wantV1 {
+		t.Errorf("ParseTCBVersion(1, %v) = %+v, want %+v", v1Vals, gotV1, wantV1)
+	}
+
+	if _, err := ParseTCBVersion(2, v1Vals); err == nil {
+		t.Errorf("ParseTCBVersion(2, %v) expected error, got nil", v1Vals)
+	}
+}
+
+func TestStructVersionForProductLine(t *testing.T) {
+	tcs := []struct {
+		productLine string
+		want        uint8
+		wantErr     bool
+	}{
+		{"Milan", 0, false},
+		{"Genoa", 0, false},
+		{"Turin", 1, false},
+		{"Unknown", 0, true},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.productLine, func(t *testing.T) {
+			got, err := StructVersionForProductLine(tc.productLine)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("StructVersionForProductLine(%q) error = %v, wantErr %v", tc.productLine, err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("StructVersionForProductLine(%q) = %d, want %d", tc.productLine, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecomposeProductTCB(t *testing.T) {
+	raw := uint64(0x0807060504030201)
+	milanTCB, err := DecomposeProductTCB("Milan", raw)
+	if err != nil {
+		t.Fatalf("DecomposeProductTCB(Milan) failed: %v", err)
+	}
+	if milanTCB.StructVersion() != 0 {
+		t.Errorf("DecomposeProductTCB(Milan).StructVersion = %d, want 0", milanTCB.StructVersion())
+	}
+	turinTCB, err := DecomposeProductTCB("Turin", raw)
+	if err != nil {
+		t.Fatalf("DecomposeProductTCB(Turin) failed: %v", err)
+	}
+	if turinTCB.StructVersion() != 1 {
+		t.Errorf("DecomposeProductTCB(Turin).StructVersion = %d, want 1", turinTCB.StructVersion())
+	}
+	if _, err := DecomposeProductTCB("Unknown", raw); err == nil {
+		t.Errorf("DecomposeProductTCB(Unknown) expected error, got nil")
+	}
+}

--- a/kds/kds_test.go
+++ b/kds/kds_test.go
@@ -37,10 +37,13 @@ func TestProductCertChainURL(t *testing.T) {
 }
 
 func TestVCEKCertURL(t *testing.T) {
-	hwid := make([]byte, abi.ChipIDSize)
+	hwid := make([]byte, VcekHWIDStruct0Size)
 	hwid[0] = 0xfe
-	hwid[abi.ChipIDSize-1] = 0xc0
-	got := VCEKCertURL("Milan", hwid, TCBVersionV0{})
+	hwid[VcekHWIDStruct0Size-1] = 0xc0
+	got, err := VCEKCertURL("Milan", hwid, TCBVersionV0{})
+	if err != nil {
+		t.Fatalf("VCEKCertURL(\"Milan\", %v, 0) unexpected error: %v", hwid, err)
+	}
 	want := "https://kdsintf.amd.com/vcek/v1/Milan/fe0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0?blSPL=0&snpSPL=0&teeSPL=0&ucodeSPL=0"
 	if got != want {
 		t.Errorf("VCEKCertURL(\"Milan\", %v, 0) = %q, want %q", hwid, got, want)
@@ -139,13 +142,63 @@ func TestParseVCEKCertURL(t *testing.T) {
 	}{
 		{
 			name: "happy path",
-			url:  VCEKCertURL("Milan", hwid, TCBVersionV0{}),
+			url: func() string {
+				u, _ := VCEKCertURL("Milan", hwid, TCBVersionV0{})
+				return u
+			}(),
 			want: func() VCEKCert {
 				c := VCEKCertProduct("Milan")
 				c.HWID = hwid
 				c.TCB = TCBVersionV0{}
 				return c
 			}(),
+		},
+		{
+			name: "happy path turin",
+			url: func() string {
+				turinHwid := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+				tcb := TCBVersionV1{
+					FmcSpl:   1,
+					BlSpl:    2,
+					TeeSpl:   3,
+					SnpSpl:   4,
+					UcodeSpl: 5,
+				}
+				u, _ := VCEKCertURL("Turin", turinHwid, tcb)
+				return u
+			}(),
+			want: func() VCEKCert {
+				c := VCEKCertProduct("Turin")
+				c.HWID = []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+				c.TCB = TCBVersionV1{
+					FmcSpl:   1,
+					BlSpl:    2,
+					TeeSpl:   3,
+					SnpSpl:   4,
+					UcodeSpl: 5,
+				}
+				return c
+			}(),
+		},
+		{
+			name:    "fmcSPL rejected on Milan",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Milan/%s?fmcSPL=1&blSPL=2", hwidhex),
+			wantErr: "unexpected KDS TCB version URL argument \"fmcSPL\" for product line \"Milan\"",
+		},
+		{
+			name:    "fmcSPL rejected on Genoa",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Genoa/%s?fmcSPL=1", hwidhex),
+			wantErr: "unexpected KDS TCB version URL argument \"fmcSPL\" for product line \"Genoa\"",
+		},
+		{
+			name:    "Turin wrong HWID length 64 bytes",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?fmcSPL=1", hwidhex),
+			wantErr: "unexpected HWID length 64 for product \"Turin\", want 8",
+		},
+		{
+			name:    "Milan wrong HWID length 8 bytes",
+			url:     "https://kdsintf.amd.com/vcek/v1/Milan/0102030405060708?blSPL=1",
+			wantErr: "unexpected HWID length 8 for product \"Milan\", want 64",
 		},
 		{
 			name:    "bad query format",
@@ -305,6 +358,22 @@ func TestParseProductName(t *testing.T) {
 			input:   "ignored",
 			key:     abi.NoneReportSigner,
 			wantErr: "internal: unhandled reportSigner",
+		},
+		{
+			name:  "happy path Turin-B0",
+			input: "Turin-B0",
+			want: &pb.SevProduct{
+				Name:            pb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			name:  "happy path Turin-B1",
+			input: "Turin-B1",
+			want: &pb.SevProduct{
+				Name:            pb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
+			},
 		},
 	}
 	for _, tc := range tcs {
@@ -559,7 +628,6 @@ func TestStructVersionForProductLine(t *testing.T) {
 		})
 	}
 }
-
 func TestDecomposeProductTCB(t *testing.T) {
 	raw := uint64(0x0807060504030201)
 	milanTCB, err := DecomposeProductTCB("Milan", raw)
@@ -578,5 +646,192 @@ func TestDecomposeProductTCB(t *testing.T) {
 	}
 	if _, err := DecomposeProductTCB("Unknown", raw); err == nil {
 		t.Errorf("DecomposeProductTCB(Unknown) expected error, got nil")
+	}
+}
+
+func TestVCEKCertURLTurin(t *testing.T) {
+	hwid := make([]byte, VcekHWIDStruct1Size)
+	hwid[0] = 0xfe
+	hwid[VcekHWIDStruct1Size-1] = 0xc0
+	tcb := TCBVersionV1{
+		FmcSpl:   1,
+		BlSpl:    2,
+		TeeSpl:   3,
+		SnpSpl:   4,
+		UcodeSpl: 5,
+	}
+	got, err := VCEKCertURL("Turin", hwid, tcb)
+	if err != nil {
+		t.Fatalf("VCEKCertURL(\"Turin\", %v, %v) unexpected error: %v", hwid, tcb, err)
+	}
+	want := "https://kdsintf.amd.com/vcek/v1/Turin/fe000000000000c0?blSPL=2&fmcSPL=1&snpSPL=4&teeSPL=3&ucodeSPL=5"
+	if got != want {
+		t.Errorf("VCEKCertURL(\"Turin\", %v, %v) = %q, want %q", hwid, tcb, got, want)
+	}
+
+	hwid64 := make([]byte, abi.ChipIDSize)
+	copy(hwid64[:VcekHWIDStruct1Size], hwid)
+	got64, err := VCEKCertURL("Turin", hwid64, tcb)
+	if err != nil {
+		t.Fatalf("VCEKCertURL(\"Turin\", %v, %v) unexpected error: %v", hwid64, tcb, err)
+	}
+	if got64 != want {
+		t.Errorf("VCEKCertURL(\"Turin\", 64-byte hwid) = %q, want %q", got64, want)
+	}
+}
+
+func TestVCEKCertURLProductMismatch(t *testing.T) {
+	hwid64 := make([]byte, VcekHWIDStruct0Size)
+	hwid8 := make([]byte, VcekHWIDStruct1Size)
+
+	// V0 struct with Turin product should fail.
+	if _, err := VCEKCertURL("Turin", hwid8, TCBVersionV0{}); err == nil {
+		t.Errorf("VCEKCertURL(\"Turin\", hwid8, TCBVersionV0{}) expected error, got nil")
+	}
+
+	// V1 struct with Milan product should fail.
+	if _, err := VCEKCertURL("Milan", hwid64, TCBVersionV1{}); err == nil {
+		t.Errorf("VCEKCertURL(\"Milan\", hwid64, TCBVersionV1{}) expected error, got nil")
+	}
+
+	// V1 struct with Genoa product should fail.
+	if _, err := VCEKCertURL("Genoa", hwid64, TCBVersionV1{}); err == nil {
+		t.Errorf("VCEKCertURL(\"Genoa\", hwid64, TCBVersionV1{}) expected error, got nil")
+	}
+}
+
+func TestVCEKCertURLNilTCB(t *testing.T) {
+	if _, err := VCEKCertURL("Turin", make([]byte, VcekHWIDStruct1Size), nil); err == nil {
+		t.Errorf("VCEKCertURL with nil TCB expected error, got nil")
+	}
+}
+
+func TestVCEKCertURLUnknownProduct(t *testing.T) {
+	if _, err := VCEKCertURL("UnknownProduct", make([]byte, 8), TCBVersionV1{}); err == nil {
+		t.Errorf("VCEKCertURL with unknown product expected error, got nil")
+	}
+}
+
+func TestVCEKCertURLInvalidHWIDLength(t *testing.T) {
+	tcs := []struct {
+		name        string
+		productLine string
+		hwidLen     int
+		tcb         TCBVersion
+		wantErr     string
+	}{
+		{
+			name:        "milan with 8-byte hwid",
+			productLine: "Milan",
+			hwidLen:     8,
+			tcb:         TCBVersionV0{},
+			wantErr:     "hwid has size 8, want 64",
+		},
+		{
+			name:        "milan with empty hwid",
+			productLine: "Milan",
+			hwidLen:     0,
+			tcb:         TCBVersionV0{},
+			wantErr:     "hwid has size 0, want 64",
+		},
+		{
+			name:        "genoa with 8-byte hwid",
+			productLine: "Genoa",
+			hwidLen:     8,
+			tcb:         TCBVersionV0{},
+			wantErr:     "hwid has size 8, want 64",
+		},
+		{
+			name:        "turin with 0-byte hwid",
+			productLine: "Turin",
+			hwidLen:     0,
+			tcb:         TCBVersionV1{},
+			wantErr:     "hwid has size 0, want 8 or 64",
+		},
+		{
+			name:        "turin with 16-byte hwid",
+			productLine: "Turin",
+			hwidLen:     16,
+			tcb:         TCBVersionV1{},
+			wantErr:     "hwid has size 16, want 8 or 64",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := VCEKCertURL(tc.productLine, make([]byte, tc.hwidLen), tc.tcb)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("VCEKCertURL(%q, %d bytes) = %v, want error containing %q", tc.productLine, tc.hwidLen, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseVCEKCertURLTurin(t *testing.T) {
+	hwid := make([]byte, 8)
+	hwid[0] = 0xfe
+	hwid[7] = 0xc0
+	hwidhex := hex.EncodeToString(hwid)
+
+	tcs := []struct {
+		name    string
+		url     string
+		want    VCEKCert
+		wantErr string
+	}{
+		{
+			name: "happy path turin",
+			url:  fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?blSPL=2&fmcSPL=1&snpSPL=4&teeSPL=3&ucodeSPL=5", hwidhex),
+			want: VCEKCert{
+				Product:     "Turin",
+				ProductLine: "Turin",
+				HWID:        hwid,
+				TCB: TCBVersionV1{
+					FmcSpl:   1,
+					BlSpl:    2,
+					TeeSpl:   3,
+					SnpSpl:   4,
+					UcodeSpl: 5,
+				},
+			},
+		},
+		{
+			name:    "blSPL exceeds 127 on Turin",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?blSPL=128&fmcSPL=1&snpSPL=4&teeSPL=3&ucodeSPL=5", hwidhex),
+			wantErr: "invalid KDS TCB version URL argument value \"128\", want a value 0-127",
+		},
+		{
+			name:    "fmcSPL exceeds 127 on Turin",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?blSPL=2&fmcSPL=128&snpSPL=4&teeSPL=3&ucodeSPL=5", hwidhex),
+			wantErr: "invalid KDS TCB version URL argument value \"128\", want a value 0-127",
+		},
+		{
+			name: "fmcSPL up to 127 allowed on Turin",
+			url:  fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?blSPL=2&fmcSPL=127&snpSPL=4&teeSPL=3&ucodeSPL=5", hwidhex),
+			want: VCEKCert{
+				Product:     "Turin",
+				ProductLine: "Turin",
+				HWID:        hwid,
+				TCB: TCBVersionV1{
+					FmcSpl:   127,
+					BlSpl:    2,
+					TeeSpl:   3,
+					SnpSpl:   4,
+					UcodeSpl: 5,
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseVCEKCertURL(tc.url)
+			if (err == nil && tc.wantErr != "") || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("ParseVCEKCertURL(%q) = _, %v, want %q", tc.url, err, tc.wantErr)
+			}
+			if err == nil {
+				if diff := cmp.Diff(got, tc.want); diff != "" {
+					t.Errorf("ParseVCEKCertURL(%q) returned unexpected diff (-want +got):\n%s", tc.url, diff)
+				}
+			}
+		})
 	}
 }

--- a/testing/fake_certs.go
+++ b/testing/fake_certs.go
@@ -431,6 +431,75 @@ func CustomExtensionsV0(tcb kds.TCBVersionV0, hwid []byte, cspid, productName st
 	return exts
 }
 
+// CustomExtensionsV1 returns an array of StructVersion 1 extensions following the KDS specification.
+func CustomExtensionsV1(tcb kds.TCBVersionV1, hwid []byte, cspid, productName string) []pkix.Extension {
+	asn1One, _ := asn1.Marshal(1)
+	var productNameAsn1 []byte
+	if hwid != nil {
+		productNameAsn1, _ = asn1.MarshalWithParams(productName, "ia5")
+	} else {
+		parts := strings.SplitN(productName, "-", 2)
+		productNameAsn1, _ = asn1.MarshalWithParams(parts[0], "ia5")
+	}
+	fmcSpl, _ := asn1.Marshal(int(tcb.FmcSpl))
+	blSpl, _ := asn1.Marshal(int(tcb.BlSpl))
+	teeSpl, _ := asn1.Marshal(int(tcb.TeeSpl))
+	snpSpl, _ := asn1.Marshal(int(tcb.SnpSpl))
+	spl5, _ := asn1.Marshal(int(tcb.Spl5))
+	spl6, _ := asn1.Marshal(int(tcb.Spl6))
+	spl7, _ := asn1.Marshal(int(tcb.Spl7))
+	ucodeSpl, _ := asn1.Marshal(int(tcb.UcodeSpl))
+	exts := []pkix.Extension{
+		{Id: kds.OidStructVersion, Value: asn1One},
+		{Id: kds.OidProductName1, Value: productNameAsn1},
+		{Id: kds.OidFmcSpl, Value: fmcSpl},
+		{Id: kds.OidBlSpl, Value: blSpl},
+		{Id: kds.OidTeeSpl, Value: teeSpl},
+		{Id: kds.OidSnpSpl, Value: snpSpl},
+		{Id: kds.OidSpl5, Value: spl5},
+		{Id: kds.OidSpl6, Value: spl6},
+		{Id: kds.OidSpl7, Value: spl7},
+		{Id: kds.OidUcodeSpl, Value: ucodeSpl},
+	}
+	if hwid != nil {
+		hwidBytes := hwid
+		if len(hwidBytes) > kds.VcekHWIDStruct1Size {
+			hwidBytes = hwidBytes[:kds.VcekHWIDStruct1Size]
+		}
+		asn1Hwid, _ := asn1.Marshal(hwidBytes)
+		exts = append(exts, pkix.Extension{Id: kds.OidHwid, Value: asn1Hwid})
+	} else {
+		if cspid == "" {
+			cspid = "placeholder"
+		}
+		asn1cspid, _ := asn1.MarshalWithParams(cspid, "ia5")
+		exts = append(exts, pkix.Extension{Id: kds.OidCspID, Value: asn1cspid})
+	}
+	return exts
+}
+
+func (b *AmdSignerBuilder) extensions(hwid []byte) []pkix.Extension {
+	tcb := b.TCB
+	if tcb == nil {
+		switch b.productLine() {
+		case "Turin":
+			tcb = kds.TCBVersionV1{}
+		case "Milan", "Genoa":
+			tcb = kds.TCBVersionV0{}
+		default:
+			return nil
+		}
+	}
+	switch v := tcb.(type) {
+	case kds.TCBVersionV1:
+		return CustomExtensionsV1(v, hwid, b.CSPID, b.productName())
+	case kds.TCBVersionV0:
+		return CustomExtensionsV0(v, hwid, b.CSPID, b.productName())
+	default:
+		return nil
+	}
+}
+
 func (b *AmdSignerBuilder) endorsementKeyPrecert(creationTime time.Time, hwid []byte, serialNumber *big.Int, key abi.ReportSigner) *x509.Certificate {
 	subject := amdPkixName(fmt.Sprintf("SEV-%s", key.String()), "0")
 	subject.SerialNumber = fmt.Sprintf("%x", serialNumber)
@@ -447,12 +516,12 @@ func (b *AmdSignerBuilder) endorsementKeyPrecert(creationTime time.Time, hwid []
 		SerialNumber:       serialNumber,
 		NotBefore:          time.Time{},
 		NotAfter:           creationTime.Add(vcekExpirationYears * 365 * 24 * time.Hour),
-		ExtraExtensions:    CustomExtensionsV0(kds.TCBVersionV0{}, hwid, b.CSPID, b.productName()),
+		ExtraExtensions:    b.extensions(hwid),
 	}
 }
 
 func (b *AmdSignerBuilder) certifyVcek() error {
-	cert := b.endorsementKeyPrecert(b.VcekCreationTime, make([]byte, abi.ChipIDSize), big.NewInt(0), abi.VcekReportSigner)
+	cert := b.endorsementKeyPrecert(b.VcekCreationTime, b.HWID[:], big.NewInt(0), abi.VcekReportSigner)
 	b.VcekCustom.override(cert)
 
 	caBytes, err := x509.CreateCertificate(insecureRandomness, cert, b.Ask, b.Keys.Vcek.Public(), b.Keys.Ask)

--- a/testing/fakekds.go
+++ b/testing/fakekds.go
@@ -116,20 +116,29 @@ func FakeKDSFromFile(path string) (*FakeKDS, error) {
 func FakeKDSFromSigner(signer *AmdSigner) (*FakeKDS, error) {
 	certs := &kpb.Certificates{}
 	rootBundles := map[string]*RootBundle{}
-	tcbVal := uint64(0)
+	productLine := kds.ProductLine(signer.Product)
+	var chipID []byte
+	switch productLine {
+	case "Milan", "Genoa":
+		chipID = signer.HWID[:]
+	case "Turin":
+		chipID = signer.HWID[:kds.VcekHWIDStruct1Size]
+	default:
+		return nil, fmt.Errorf("unknown product line: %q", productLine)
+	}
+	var tcbVal uint64
 	if signer.TCB != nil {
 		tcbVal = signer.TCB.Uint64()
 	}
 	certs.ChipCerts = []*kpb.Certificates_ChipTCBCerts{
 		{
-			ChipId: signer.HWID[:],
+			ChipId: chipID,
 			TcbCerts: map[uint64][]byte{
 				tcbVal: signer.Vcek.Raw,
 			},
 			Fms: abi.MaskedCpuid1EaxFromSevProduct(signer.Product),
 		},
 	}
-	productLine := kds.ProductLine(signer.Product)
 
 	b := &strings.Builder{}
 	if err := multierr.Combine(

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -810,7 +810,18 @@ func fillInAttestation(ctx context.Context, attestation *spb.Attestation, option
 	switch info.SigningKey {
 	case abi.VcekReportSigner:
 		if len(chain.GetVcekCert()) == 0 {
-			vcekURL := kds.VCEKCertURL(productLine, report.GetChipId(), kds.DecomposeTCBVersionV0(report.GetReportedTcb()))
+			tcb, err := kds.DecomposeProductTCB(productLine, report.GetReportedTcb())
+			if err != nil {
+				return &trust.AttestationRecreationErr{
+					Msg: fmt.Sprintf("could not decompose reported TCB: %v", err),
+				}
+			}
+			vcekURL, err := kds.VCEKCertURL(productLine, report.GetChipId(), tcb)
+			if err != nil {
+				return &trust.AttestationRecreationErr{
+					Msg: fmt.Sprintf("could not construct VCEK certificate URL: %v", err),
+				}
+			}
 			vcek, err := trust.GetWith(ctx, getter, vcekURL)
 			if err != nil {
 				return &trust.AttestationRecreationErr{


### PR DESCRIPTION
Depends on #196 and #197.

Add support for AMD Family 1Ah (Turin) VCEK certificate URL generation and x509 extension parsing per AMD Publication #57230 Tables 11, 12, 13:
- Define `VcekHWIDStruct0Size` (64 bytes) and `VcekHWIDStruct1Size` (8 bytes) for VCEK certificate HWID extension lengths.
- Define `OidFmcSpl` (`1.3.6.1.4.1.3704.1.3.9`) for the FMC SPL extension.
- Update `VCEKCertURL` to format 16-hex character HWID and query parameters for Turin, and accept either an 8-byte Silicon ID or a 64-byte report `CHIP_ID`.
- Update `ParseVCEKCertURL` to parse Turin VCEK URLs and TCB parameters.
- Update `VcekCertificateExtensions` to validate HWID lengths and parse `TCBVersionV1` when `StructVersion` is 1.
- Update fake certs test helpers to support Turin certificates.