### PR TITLE
validate, verify: add attestation report and certificate validation for Turin

### DIFF
--- a/abi/abi.go
+++ b/abi/abi.go
@@ -61,8 +61,12 @@ const (
 	ReportIDSize = 32
 	// ReportIDMASize is the field size of REPORT_ID_MA in an SEV-SNP attestation report.
 	ReportIDMASize = 32
-	// ChipIDSize is the field size of CHIP_ID in an SEV-SNP attestation report.
+	// ChipIDSize is the field size of CHIP_ID in an SEV-SNP attestation report
+	// (AMD Publication #56860 Table 23).
 	ChipIDSize = 64
+	// TurinSiliconIDSize is the field size of the Silicon ID in an SEV-SNP attestation
+	// report on Family 1Ah (Turin) processors (AMD Publication #56860 Table 23).
+	TurinSiliconIDSize = 8
 	// SignatureSize is the field size of SIGNATURE in an SEV-SNP attestation report.
 	SignatureSize = 512
 
@@ -1038,8 +1042,10 @@ func SevProductFromCpuid1Eax(eax uint32) *pb.SevProduct {
 			unknown()
 		}
 	case zen5Family:
-		switch model {
-		case turinModel:
+		// Table 4 of https://www.amd.com/system/files/TechDocs/57230.pdf defines Turin as
+		// Family 1Ah with Extended Model 0h or 1h. Shifting model >> 4 yields Extended Model.
+		switch model >> 4 {
+		case 0, 1:
 			productName = pb.SevProduct_SEV_PRODUCT_TURIN
 		default:
 			unknown()

--- a/abi/abi_test.go
+++ b/abi/abi_test.go
@@ -439,6 +439,44 @@ func TestSevProduct(t *testing.T) {
 				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
 			},
 		},
+		{
+			eax: 0x00b10f20,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			eax: 0x00b10f21,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
+			},
+		},
+		{
+			// Turin with base model 0 (0x00b00f00)
+			eax: 0x00b00f00,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			// Turin Dense / Zen 5c with base model 1 (0x00b10f10)
+			eax: 0x00b10f10,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			// Zen 5 Family 1Ah with Extended Model 2 (unmapped) -> Unknown
+			eax: 0x00b20f00,
+			want: &spb.SevProduct{
+				Name:            spb.SevProduct_SEV_PRODUCT_UNKNOWN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(fmt.Sprintf("EAX_0x%x", tc.eax), func(t *testing.T) {

--- a/kds/kds.go
+++ b/kds/kds.go
@@ -21,6 +21,7 @@ import (
 	"encoding/asn1"
 	"encoding/hex"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -59,6 +60,8 @@ var (
 	OidSpl7 = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 3704, 1, 3, 7})
 	// OidUcodeSpl is the x509v3 extension for V[CL]EK microcode security patch level.
 	OidUcodeSpl = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 3704, 1, 3, 8})
+	// OidFmcSpl is the x509v3 extension for FMC SPL (Zen 5 / Turin only).
+	OidFmcSpl = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 3704, 1, 3, 9})
 	// OidHwid is the x509v3 extension for VCEK certificate associated hardware identifier.
 	OidHwid = asn1.ObjectIdentifier([]int{1, 3, 6, 1, 4, 1, 3704, 1, 4})
 	// OidCspID is the x509v3 extension for a VLEK certificate's Cloud Service Provider's
@@ -78,6 +81,7 @@ var (
 	kdsSpl6          = kdsOID{major: 3, minor: 6}
 	kdsSpl7          = kdsOID{major: 3, minor: 7}
 	kdsUcodeSpl      = kdsOID{major: 3, minor: 8}
+	kdsFmcSpl        = kdsOID{major: 3, minor: 9}
 	kdsHwid          = kdsOID{major: 4}
 	kdsCspID         = kdsOID{major: 5}
 
@@ -85,6 +89,13 @@ var (
 	kdsBaseURL  = "https://" + kdsHostname
 	kdsVcekPath = "/vcek/v1/"
 	kdsVlekPath = "/vlek/v1/"
+
+	// VcekHWIDStruct0Size is the HWID extension byte length in StructVersion 0 VCEK certificates
+	// (Family 19h: Milan, Genoa) per AMD Publication #57230 Table 10.
+	VcekHWIDStruct0Size = 64
+	// VcekHWIDStruct1Size is the HWID extension byte length in StructVersion 1 VCEK certificates
+	// (Family 1Ah: Turin) per AMD Publication #57230 Table 11.
+	VcekHWIDStruct1Size = 8
 
 	uint0 = &wrapperspb.UInt32Value{Value: 0}
 	uint1 = &wrapperspb.UInt32Value{Value: 1}
@@ -111,6 +122,7 @@ var (
 		0x00a00f10: "Milan",
 		0x00a10f10: "Genoa",
 		0x00b00f20: "Turin",
+		0x00b10f20: "Turin",
 	}
 )
 
@@ -134,8 +146,8 @@ type Extensions struct {
 	StructVersion uint8
 	ProductName   string
 	// The host driver knows the difference between primary and secondary HWID.
-	// Primary vs secondary is irrelevant to verification. Must be nil or
-	// abi.ChipIDSize long.
+	// Primary vs secondary is irrelevant to verification. Must be nil,
+	// VcekHWIDStruct0Size long (for StructVersion 0), or VcekHWIDStruct1Size long (for StructVersion 1).
 	HWID       []byte
 	TCBVersion TCBVersion
 	CspID      string
@@ -174,6 +186,9 @@ func oidTokdsOID(id asn1.ObjectIdentifier) (kdsOID, error) {
 	}
 	if id.Equal(OidUcodeSpl) {
 		return kdsUcodeSpl, nil
+	}
+	if id.Equal(OidFmcSpl) {
+		return kdsFmcSpl, nil
 	}
 	if id.Equal(OidCspID) {
 		return kdsCspID, nil
@@ -281,13 +296,10 @@ func DecomposeTCBVersionV0(raw uint64) TCBVersionV0 {
 }
 
 // ParseTCBVersionV0 parses KDS REST query parameters into a TCBVersionV0.
-// Valid parameter value ranges are specified in AMD Publication #57230 Table 12
-// (Milan and Genoa REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
 func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 	var blSpl, teeSpl, snpSpl, ucodeSpl uint8
 	for key, valuelist := range values {
 		var setter func(number uint8)
-		// AMD Publication #57230 Table 12: blSPL, teeSPL, snpSPL are in the range 0..127.
 		maxVal := 127
 		switch key {
 		case "blSPL":
@@ -297,7 +309,6 @@ func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 		case "snpSPL":
 			setter = func(number uint8) { snpSpl = number }
 		case "ucodeSPL":
-			// AMD Publication #57230 Table 12: ucodeSPL is in the range 0..255.
 			maxVal = 255
 			setter = func(number uint8) { ucodeSpl = number }
 		default:
@@ -401,13 +412,10 @@ func DecomposeTCBVersionV1(raw uint64) TCBVersionV1 {
 }
 
 // ParseTCBVersionV1 parses KDS REST query parameters into a TCBVersionV1.
-// Valid parameter value ranges are specified in AMD Publication #57230 Table 13
-// (Turin REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
 func ParseTCBVersionV1(values url.Values) (TCBVersionV1, error) {
 	var fmcSpl, blSpl, teeSpl, snpSpl, ucodeSpl uint8
 	for key, valuelist := range values {
 		var setter func(number uint8)
-		// AMD Publication #57230 Table 13: fmcSPL, blSPL, teeSPL, snpSPL are in the range 0..127.
 		maxVal := 127
 		switch key {
 		case "fmcSPL":
@@ -419,7 +427,6 @@ func ParseTCBVersionV1(values url.Values) (TCBVersionV1, error) {
 		case "snpSPL":
 			setter = func(number uint8) { snpSpl = number }
 		case "ucodeSPL":
-			// AMD Publication #57230 Table 13: ucodeSPL is in the range 0..255.
 			maxVal = 255
 			setter = func(number uint8) { ucodeSpl = number }
 		default:
@@ -485,6 +492,19 @@ func DecomposeProductTCB(productLine string, raw uint64) (TCBVersion, error) {
 		return nil, err
 	}
 	return DecomposeTCBVersion(v, raw)
+}
+
+// ParseProductTCBVersion parses query parameters into a TCBVersion based on productLine.
+func ParseProductTCBVersion(productLine string, values url.Values) (TCBVersion, error) {
+	v, err := StructVersionForProductLine(productLine)
+	if err != nil {
+		return nil, err
+	}
+	tcb, err := ParseTCBVersion(v, values)
+	if err != nil {
+		return nil, fmt.Errorf("%w for product line %q", err, productLine)
+	}
+	return tcb, nil
 }
 
 func asn1U8(ext *pkix.Extension, field string, out *uint8) error {
@@ -561,7 +581,16 @@ func kdsOidMapToExtensions(exts map[kdsOID]*pkix.Extension) (*Extensions, error)
 	}
 	hwidExt, ok := exts[kdsHwid]
 	if ok {
-		octet, err := asn1OctetString(hwidExt, "HWID", 64)
+		var expectedLen int
+		switch result.StructVersion {
+		case 0:
+			expectedLen = VcekHWIDStruct0Size
+		case 1:
+			expectedLen = VcekHWIDStruct1Size
+		default:
+			return nil, fmt.Errorf("unsupported structVersion %d", result.StructVersion)
+		}
+		octet, err := asn1OctetString(hwidExt, "HWID", expectedLen)
 		if err != nil {
 			return nil, err
 		}
@@ -586,9 +615,6 @@ func kdsOidMapToExtensions(exts map[kdsOID]*pkix.Extension) (*Extensions, error)
 	if err := asn1U8(exts[kdsSnpSpl], "SnpSpl", &snpspl); err != nil {
 		return nil, err
 	}
-	if err := asn1U8(exts[kdsSpl4], "Spl4", &spl4); err != nil {
-		return nil, err
-	}
 	if err := asn1U8(exts[kdsSpl5], "Spl5", &spl5); err != nil {
 		return nil, err
 	}
@@ -601,17 +627,47 @@ func kdsOidMapToExtensions(exts map[kdsOID]*pkix.Extension) (*Extensions, error)
 	if err := asn1U8(exts[kdsUcodeSpl], "UcodeSpl", &ucodespl); err != nil {
 		return nil, err
 	}
-	result.TCBVersion = TCBVersionV0{
-		BlSpl:    blspl,
-		TeeSpl:   teespl,
-		Spl4:     spl4,
-		Spl5:     spl5,
-		Spl6:     spl6,
-		Spl7:     spl7,
-		SnpSpl:   snpspl,
-		UcodeSpl: ucodespl,
+	switch result.StructVersion {
+	case 0:
+		if exts[kdsFmcSpl] != nil {
+			return nil, fmt.Errorf("unexpected fmcSPL extension for structVersion 0")
+		}
+		if err := asn1U8(exts[kdsSpl4], "Spl4", &spl4); err != nil {
+			return nil, err
+		}
+		result.TCBVersion = TCBVersionV0{
+			BlSpl:    blspl,
+			TeeSpl:   teespl,
+			Spl4:     spl4,
+			Spl5:     spl5,
+			Spl6:     spl6,
+			Spl7:     spl7,
+			SnpSpl:   snpspl,
+			UcodeSpl: ucodespl,
+		}
+		return &result, nil
+	case 1:
+		if exts[kdsSpl4] != nil {
+			return nil, fmt.Errorf("unexpected spl4 extension for structVersion 1")
+		}
+		var fmcspl uint8
+		if err := asn1U8(exts[kdsFmcSpl], "FmcSpl", &fmcspl); err != nil {
+			return nil, err
+		}
+		result.TCBVersion = TCBVersionV1{
+			FmcSpl:   fmcspl,
+			BlSpl:    blspl,
+			TeeSpl:   teespl,
+			SnpSpl:   snpspl,
+			Spl5:     spl5,
+			Spl6:     spl6,
+			Spl7:     spl7,
+			UcodeSpl: ucodespl,
+		}
+		return &result, nil
+	default:
+		return nil, fmt.Errorf("unsupported structVersion %d", result.StructVersion)
 	}
-	return &result, nil
 }
 
 // preEndorsementKeyCertificateExtensions returns the x509v3 extensions from the KDS specification interpreted
@@ -641,8 +697,17 @@ func VcekCertificateExtensions(cert *x509.Certificate) (*Extensions, error) {
 	if exts.CspID != "" {
 		return nil, fmt.Errorf("unexpected CSP_ID in VCEK certificate: %s", exts.CspID)
 	}
-	if len(exts.HWID) != abi.ChipIDSize {
-		return nil, fmt.Errorf("missing HWID extension for VCEK certificate")
+	var expectedHwidLen int
+	switch exts.StructVersion {
+	case 0:
+		expectedHwidLen = VcekHWIDStruct0Size
+	case 1:
+		expectedHwidLen = VcekHWIDStruct1Size
+	default:
+		return nil, fmt.Errorf("unsupported structVersion %d", exts.StructVersion)
+	}
+	if len(exts.HWID) != expectedHwidLen {
+		return nil, fmt.Errorf("VCEK certificate HWID expected %d bytes, got %d", expectedHwidLen, len(exts.HWID))
 	}
 	return exts, nil
 }
@@ -725,14 +790,59 @@ func ProductCertChainURL(s abi.ReportSigner, productLine string) string {
 	return fmt.Sprintf("%s/cert_chain", productBaseURL(s, productLine))
 }
 
+func validateProductTCB(product string, tcb TCBVersion) error {
+	if tcb == nil {
+		return errors.New("tcb cannot be nil")
+	}
+	expectedVersion, err := StructVersionForProductLine(product)
+	if err != nil {
+		return err
+	}
+	if tcb.StructVersion() != expectedVersion {
+		return fmt.Errorf("product %q requires TCB StructVersion %d, got %d", product, expectedVersion, tcb.StructVersion())
+	}
+	return nil
+}
+
 // VCEKCertURL returns the AMD KDS URL for retrieving the VCEK on a given product
-// at a given TCB version. The hwid is the CHIP_ID field in an attestation report.
-func VCEKCertURL(productLine string, hwid []byte, tcb TCBVersion) string {
+// at a given TCB version. The hwid may be either the raw silicon ID or the 64-byte
+// CHIP_ID field from an attestation report.
+//
+// Per AMD Publication #57230 Table 13, the KDS REST endpoint expects a hexadecimal
+// hwID string of:
+//   - 128 hex characters (VcekHWIDStruct0Size bytes) for Family 19h (Milan, Genoa, Siena)
+//   - 16 hex characters (VcekHWIDStruct1Size bytes) for Family 1Ah (Turin and later)
+//
+// If a 64-byte attestation report CHIP_ID (abi.ChipIDSize) is passed for Turin,
+// the first VcekHWIDStruct1Size bytes are used.
+func VCEKCertURL(productLine string, hwid []byte, tcb TCBVersion) (string, error) {
+	if err := validateProductTCB(productLine, tcb); err != nil {
+		return "", err
+	}
+	var hwidBytes []byte
+	switch productLine {
+	case "Milan", "Genoa":
+		if len(hwid) != VcekHWIDStruct0Size {
+			return "", fmt.Errorf("hwid has size %d, want %d", len(hwid), VcekHWIDStruct0Size)
+		}
+		hwidBytes = hwid
+	case "Turin":
+		switch len(hwid) {
+		case VcekHWIDStruct1Size:
+			hwidBytes = hwid
+		case abi.ChipIDSize:
+			hwidBytes = hwid[:VcekHWIDStruct1Size]
+		default:
+			return "", fmt.Errorf("hwid has size %d, want %d or %d", len(hwid), VcekHWIDStruct1Size, abi.ChipIDSize)
+		}
+	default:
+		return "", fmt.Errorf("unknown product line: %q", productLine)
+	}
 	return fmt.Sprintf("%s/%s?%s",
 		productBaseURL(abi.VcekReportSigner, productLine),
-		hex.EncodeToString(hwid),
+		hex.EncodeToString(hwidBytes),
 		tcb.Values().Encode(),
-	)
+	), nil
 }
 
 // VLEKCertURL returns the GET URL for retrieving a VLEK certificate, but without the necessary
@@ -846,12 +956,12 @@ func ParseProductCertChainURL(kdsurl string) (string, CertFunction, error) {
 	return parsed.productLine, parsed.function, nil
 }
 
-func parseTCBURL(u *url.URL) (TCBVersionV0, error) {
+func parseTCBURL(productLine string, u *url.URL) (TCBVersion, error) {
 	values, err := url.ParseQuery(u.RawQuery)
 	if err != nil {
-		return TCBVersionV0{}, fmt.Errorf("invalid AMD KDS URL query %q: %v", u.RawQuery, err)
+		return nil, fmt.Errorf("invalid AMD KDS URL query %q: %v", u.RawQuery, err)
 	}
-	return ParseTCBVersionV0(values)
+	return ParseProductTCBVersion(productLine, values)
 }
 
 // ParseVCEKCertURL returns the attestation report components represented in the given KDS VCEK
@@ -871,14 +981,25 @@ func ParseVCEKCertURL(kdsurl string) (VCEKCert, error) {
 	if err != nil {
 		return result, fmt.Errorf("hwid component of KDS URL is not a hex string: %q", parsed.simpleURL.Path)
 	}
-	if len(hwid) != abi.ChipIDSize {
-		return result, fmt.Errorf("hwid component of KDS URL has size %d, want %d", len(hwid), abi.ChipIDSize)
+	var expectedHwidLen int
+	switch parsed.productLine {
+	case "Milan", "Genoa":
+		expectedHwidLen = VcekHWIDStruct0Size
+	case "Turin":
+		expectedHwidLen = VcekHWIDStruct1Size
+	default:
+		return result, fmt.Errorf("unexpected product %q in VCEK URL", parsed.productLine)
 	}
-
+	if len(hwid) != expectedHwidLen {
+		return result, fmt.Errorf("unexpected HWID length %d for product %q, want %d", len(hwid), parsed.productLine, expectedHwidLen)
+	}
 	result.HWID = hwid
-
-	result.TCB, err = parseTCBURL(parsed.simpleURL)
-	return result, err
+	tcb, err := parseTCBURL(parsed.productLine, parsed.simpleURL)
+	if err != nil {
+		return result, err
+	}
+	result.TCB = tcb
+	return result, nil
 }
 
 // ParseVLEKCertURL returns the attestation report components represented in the given KDS VLEK
@@ -898,7 +1019,7 @@ func ParseVLEKCertURL(kdsurl string) (VLEKCert, error) {
 		return result, fmt.Errorf("vlek function is %q, want 'cert'", parsed.simpleURL.Path)
 	}
 
-	result.TCB, err = parseTCBURL(parsed.simpleURL)
+	result.TCB, err = parseTCBURL(parsed.productLine, parsed.simpleURL)
 	return result, err
 }
 

--- a/kds/kds.go
+++ b/kds/kds.go
@@ -281,10 +281,13 @@ func DecomposeTCBVersionV0(raw uint64) TCBVersionV0 {
 }
 
 // ParseTCBVersionV0 parses KDS REST query parameters into a TCBVersionV0.
+// Valid parameter value ranges are specified in AMD Publication #57230 Table 12
+// (Milan and Genoa REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
 func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 	var blSpl, teeSpl, snpSpl, ucodeSpl uint8
 	for key, valuelist := range values {
 		var setter func(number uint8)
+		// AMD Publication #57230 Table 12: blSPL, teeSPL, snpSPL are in the range 0..127.
 		maxVal := 127
 		switch key {
 		case "blSPL":
@@ -294,6 +297,7 @@ func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 		case "snpSPL":
 			setter = func(number uint8) { snpSpl = number }
 		case "ucodeSPL":
+			// AMD Publication #57230 Table 12: ucodeSPL is in the range 0..255.
 			maxVal = 255
 			setter = func(number uint8) { ucodeSpl = number }
 		default:
@@ -313,6 +317,174 @@ func ParseTCBVersionV0(values url.Values) (TCBVersionV0, error) {
 		SnpSpl:   snpSpl,
 		UcodeSpl: ucodeSpl,
 	}, nil
+}
+
+// TCBVersionV1 represents the platform security patch levels for StructVersion 1 (Turin).
+type TCBVersionV1 struct {
+	// FmcSpl is the FMC security patch level.
+	FmcSpl uint8
+	// BlSpl is the bootloader security patch level.
+	BlSpl uint8
+	// TeeSpl is the TEE security patch level.
+	TeeSpl uint8
+	// SnpSpl is the SNP security patch level.
+	SnpSpl uint8
+	// Spl5 is reserved.
+	Spl5 uint8
+	// Spl6 is reserved.
+	Spl6 uint8
+	// Spl7 is reserved.
+	Spl7 uint8
+	// UcodeSpl is the microcode security patch level.
+	UcodeSpl uint8
+}
+
+// StructVersion returns 1 for Turin.
+func (t TCBVersionV1) StructVersion() uint8 { return 1 }
+
+// Uint64 returns the 64-bit wire representation of TCBVersionV1.
+func (t TCBVersionV1) Uint64() uint64 {
+	return (uint64(t.UcodeSpl) << 56) |
+		(uint64(t.Spl7) << 48) |
+		(uint64(t.Spl6) << 40) |
+		(uint64(t.Spl5) << 32) |
+		(uint64(t.SnpSpl) << 24) |
+		(uint64(t.TeeSpl) << 16) |
+		(uint64(t.BlSpl) << 8) |
+		(uint64(t.FmcSpl) << 0)
+}
+
+// Values encodes TCBVersionV1 into KDS REST URL query parameters.
+func (t TCBVersionV1) Values() url.Values {
+	values := make(url.Values)
+	values.Set("fmcSPL", fmt.Sprintf("%d", t.FmcSpl))
+	values.Set("blSPL", fmt.Sprintf("%d", t.BlSpl))
+	values.Set("teeSPL", fmt.Sprintf("%d", t.TeeSpl))
+	values.Set("snpSPL", fmt.Sprintf("%d", t.SnpSpl))
+	values.Set("ucodeSPL", fmt.Sprintf("%d", t.UcodeSpl))
+	return values
+}
+
+// LE returns true iff all TCB components of t are <= the corresponding components of other.
+func (t TCBVersionV1) LE(other TCBVersion) bool {
+	o, ok := other.(TCBVersionV1)
+	if !ok {
+		return false
+	}
+	return t.UcodeSpl <= o.UcodeSpl &&
+		t.Spl7 <= o.Spl7 &&
+		t.Spl6 <= o.Spl6 &&
+		t.Spl5 <= o.Spl5 &&
+		t.SnpSpl <= o.SnpSpl &&
+		t.TeeSpl <= o.TeeSpl &&
+		t.BlSpl <= o.BlSpl &&
+		t.FmcSpl <= o.FmcSpl
+}
+
+func (t TCBVersionV1) String() string {
+	return fmt.Sprintf("{FmcSpl:%d BlSpl:%d TeeSpl:%d SnpSpl:%d Spl5:%d Spl6:%d Spl7:%d UcodeSpl:%d}",
+		t.FmcSpl, t.BlSpl, t.TeeSpl, t.SnpSpl, t.Spl5, t.Spl6, t.Spl7, t.UcodeSpl)
+}
+
+// DecomposeTCBVersionV1 decomposes a 64-bit raw TCB integer into a TCBVersionV1.
+func DecomposeTCBVersionV1(raw uint64) TCBVersionV1 {
+	return TCBVersionV1{
+		FmcSpl:   uint8(raw & 0xff),
+		BlSpl:    uint8((raw >> 8) & 0xff),
+		TeeSpl:   uint8((raw >> 16) & 0xff),
+		SnpSpl:   uint8((raw >> 24) & 0xff),
+		Spl5:     uint8((raw >> 32) & 0xff),
+		Spl6:     uint8((raw >> 40) & 0xff),
+		Spl7:     uint8((raw >> 48) & 0xff),
+		UcodeSpl: uint8((raw >> 56) & 0xff),
+	}
+}
+
+// ParseTCBVersionV1 parses KDS REST query parameters into a TCBVersionV1.
+// Valid parameter value ranges are specified in AMD Publication #57230 Table 13
+// (Turin REST API Parameters): ucodeSPL is in 0..255; all other SPL fields are in 0..127.
+func ParseTCBVersionV1(values url.Values) (TCBVersionV1, error) {
+	var fmcSpl, blSpl, teeSpl, snpSpl, ucodeSpl uint8
+	for key, valuelist := range values {
+		var setter func(number uint8)
+		// AMD Publication #57230 Table 13: fmcSPL, blSPL, teeSPL, snpSPL are in the range 0..127.
+		maxVal := 127
+		switch key {
+		case "fmcSPL":
+			setter = func(number uint8) { fmcSpl = number }
+		case "blSPL":
+			setter = func(number uint8) { blSpl = number }
+		case "teeSPL":
+			setter = func(number uint8) { teeSpl = number }
+		case "snpSPL":
+			setter = func(number uint8) { snpSpl = number }
+		case "ucodeSPL":
+			// AMD Publication #57230 Table 13: ucodeSPL is in the range 0..255.
+			maxVal = 255
+			setter = func(number uint8) { ucodeSpl = number }
+		default:
+			return TCBVersionV1{}, fmt.Errorf("unexpected KDS TCB version URL argument %q", key)
+		}
+		for _, val := range valuelist {
+			number, err := strconv.Atoi(val)
+			if err != nil || number < 0 || number > maxVal {
+				return TCBVersionV1{}, fmt.Errorf("invalid KDS TCB version URL argument value %q, want a value 0-%d", val, maxVal)
+			}
+			setter(uint8(number))
+		}
+	}
+	return TCBVersionV1{
+		FmcSpl:   fmcSpl,
+		BlSpl:    blSpl,
+		TeeSpl:   teeSpl,
+		SnpSpl:   snpSpl,
+		UcodeSpl: ucodeSpl,
+	}, nil
+}
+
+// DecomposeTCBVersion decomposes a raw 64-bit TCB integer into a TCBVersion for the given structVersion.
+func DecomposeTCBVersion(structVersion uint8, raw uint64) (TCBVersion, error) {
+	switch structVersion {
+	case 0:
+		return DecomposeTCBVersionV0(raw), nil
+	case 1:
+		return DecomposeTCBVersionV1(raw), nil
+	default:
+		return nil, fmt.Errorf("unsupported TCB structVersion: %d", structVersion)
+	}
+}
+
+// ParseTCBVersion parses query parameters into a TCBVersion based on structVersion.
+func ParseTCBVersion(structVersion uint8, values url.Values) (TCBVersion, error) {
+	switch structVersion {
+	case 0:
+		return ParseTCBVersionV0(values)
+	case 1:
+		return ParseTCBVersionV1(values)
+	default:
+		return nil, fmt.Errorf("unsupported TCB structVersion: %d", structVersion)
+	}
+}
+
+// StructVersionForProductLine returns the TCB StructVersion (0 or 1) for a given productLine.
+func StructVersionForProductLine(productLine string) (uint8, error) {
+	switch productLine {
+	case "Milan", "Genoa":
+		return 0, nil
+	case "Turin":
+		return 1, nil
+	default:
+		return 0, fmt.Errorf("unknown product line: %q", productLine)
+	}
+}
+
+// DecomposeProductTCB decomposes a raw 64-bit TCB integer into a TCBVersion for the given productLine.
+func DecomposeProductTCB(productLine string, raw uint64) (TCBVersion, error) {
+	v, err := StructVersionForProductLine(productLine)
+	if err != nil {
+		return nil, err
+	}
+	return DecomposeTCBVersion(v, raw)
 }
 
 func asn1U8(ext *pkix.Extension, field string, out *uint8) error {

--- a/kds/kds_test.go
+++ b/kds/kds_test.go
@@ -394,3 +394,189 @@ func TestTCBVersionV0(t *testing.T) {
 		}
 	}
 }
+
+func TestTCBVersionV1(t *testing.T) {
+	tcb := TCBVersionV1{
+		FmcSpl:   1,
+		BlSpl:    2,
+		TeeSpl:   3,
+		SnpSpl:   4,
+		Spl5:     5,
+		Spl6:     6,
+		Spl7:     7,
+		UcodeSpl: 8,
+	}
+	if tcb.FmcSpl != 1 || tcb.BlSpl != 2 || tcb.TeeSpl != 3 || tcb.SnpSpl != 4 ||
+		tcb.Spl5 != 5 || tcb.Spl6 != 6 || tcb.Spl7 != 7 || tcb.UcodeSpl != 8 {
+		t.Errorf("TCBVersionV1 fields failed: got fmc=%d bl=%d tee=%d snp=%d spl5=%d spl6=%d spl7=%d ucode=%d",
+			tcb.FmcSpl, tcb.BlSpl, tcb.TeeSpl, tcb.SnpSpl, tcb.Spl5, tcb.Spl6, tcb.Spl7, tcb.UcodeSpl)
+	}
+	if tcb.StructVersion() != 1 {
+		t.Errorf("StructVersion() = %d, want 1", tcb.StructVersion())
+	}
+
+	raw := tcb.Uint64()
+	decomposed := DecomposeTCBVersionV1(raw)
+	if decomposed != tcb {
+		t.Errorf("DecomposeTCBVersionV1(0x%x) = %+v, want %+v", raw, decomposed, tcb)
+	}
+
+	vals := tcb.Values()
+	parsed, err := ParseTCBVersionV1(vals)
+	if err != nil {
+		t.Fatalf("ParseTCBVersionV1(%v) failed: %v", vals, err)
+	}
+	wantParsed := TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, UcodeSpl: 8}
+	if parsed != wantParsed {
+		t.Errorf("ParseTCBVersionV1(%v) = %+v, want %+v", vals, parsed, wantParsed)
+	}
+
+	base := TCBVersionV1{
+		FmcSpl:   10,
+		BlSpl:    10,
+		TeeSpl:   10,
+		SnpSpl:   10,
+		Spl5:     10,
+		Spl6:     10,
+		Spl7:     10,
+		UcodeSpl: 10,
+	}
+	if !base.LE(base) {
+		t.Errorf("expected base.LE(base) to be true")
+	}
+
+	higherFields := []struct {
+		name string
+		tcb  TCBVersionV1
+	}{
+		{"FmcSpl", TCBVersionV1{FmcSpl: 11, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"BlSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 11, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"TeeSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 11, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"SnpSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 11, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"Spl5", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 11, Spl6: 10, Spl7: 10, UcodeSpl: 10}},
+		{"Spl6", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 11, Spl7: 10, UcodeSpl: 10}},
+		{"Spl7", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 11, UcodeSpl: 10}},
+		{"UcodeSpl", TCBVersionV1{FmcSpl: 10, BlSpl: 10, TeeSpl: 10, SnpSpl: 10, Spl5: 10, Spl6: 10, Spl7: 10, UcodeSpl: 11}},
+	}
+	for _, tc := range higherFields {
+		t.Run("LE_"+tc.name, func(t *testing.T) {
+			if !base.LE(tc.tcb) {
+				t.Errorf("expected base.LE(higher) to be true")
+			}
+			if tc.tcb.LE(base) {
+				t.Errorf("expected higher.LE(base) to be false")
+			}
+		})
+	}
+}
+
+func TestDecomposeTCBVersion(t *testing.T) {
+	tcs := []struct {
+		name          string
+		structVersion uint8
+		raw           uint64
+		want          TCBVersion
+		wantErr       bool
+	}{
+		{
+			name:          "StructVersion 0",
+			structVersion: 0,
+			raw:           0x0807060504030201,
+			want:          TCBVersionV0{BlSpl: 1, TeeSpl: 2, Spl4: 3, Spl5: 4, Spl6: 5, Spl7: 6, SnpSpl: 7, UcodeSpl: 8},
+		},
+		{
+			name:          "StructVersion 1",
+			structVersion: 1,
+			raw:           0x0807060504030201,
+			want:          TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, Spl5: 5, Spl6: 6, Spl7: 7, UcodeSpl: 8},
+		},
+		{
+			name:          "unsupported StructVersion",
+			structVersion: 2,
+			raw:           0,
+			wantErr:       true,
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := DecomposeTCBVersion(tc.structVersion, tc.raw)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("DecomposeTCBVersion(%d, 0x%x) error = %v, wantErr %v", tc.structVersion, tc.raw, err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("DecomposeTCBVersion(%d, 0x%x) = %+v, want %+v", tc.structVersion, tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseTCBVersion(t *testing.T) {
+	v0Vals := TCBVersionV0{BlSpl: 1, TeeSpl: 2, SnpSpl: 3, UcodeSpl: 4}.Values()
+	gotV0, err := ParseTCBVersion(0, v0Vals)
+	if err != nil {
+		t.Fatalf("ParseTCBVersion(0, %v) failed: %v", v0Vals, err)
+	}
+	wantV0 := TCBVersionV0{BlSpl: 1, TeeSpl: 2, SnpSpl: 3, UcodeSpl: 4}
+	if gotV0 != wantV0 {
+		t.Errorf("ParseTCBVersion(0, %v) = %+v, want %+v", v0Vals, gotV0, wantV0)
+	}
+
+	v1Vals := TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, UcodeSpl: 5}.Values()
+	gotV1, err := ParseTCBVersion(1, v1Vals)
+	if err != nil {
+		t.Fatalf("ParseTCBVersion(1, %v) failed: %v", v1Vals, err)
+	}
+	wantV1 := TCBVersionV1{FmcSpl: 1, BlSpl: 2, TeeSpl: 3, SnpSpl: 4, UcodeSpl: 5}
+	if gotV1 != wantV1 {
+		t.Errorf("ParseTCBVersion(1, %v) = %+v, want %+v", v1Vals, gotV1, wantV1)
+	}
+
+	if _, err := ParseTCBVersion(2, v1Vals); err == nil {
+		t.Errorf("ParseTCBVersion(2, %v) expected error, got nil", v1Vals)
+	}
+}
+
+func TestStructVersionForProductLine(t *testing.T) {
+	tcs := []struct {
+		productLine string
+		want        uint8
+		wantErr     bool
+	}{
+		{"Milan", 0, false},
+		{"Genoa", 0, false},
+		{"Turin", 1, false},
+		{"Unknown", 0, true},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.productLine, func(t *testing.T) {
+			got, err := StructVersionForProductLine(tc.productLine)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("StructVersionForProductLine(%q) error = %v, wantErr %v", tc.productLine, err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("StructVersionForProductLine(%q) = %d, want %d", tc.productLine, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDecomposeProductTCB(t *testing.T) {
+	raw := uint64(0x0807060504030201)
+	milanTCB, err := DecomposeProductTCB("Milan", raw)
+	if err != nil {
+		t.Fatalf("DecomposeProductTCB(Milan) failed: %v", err)
+	}
+	if milanTCB.StructVersion() != 0 {
+		t.Errorf("DecomposeProductTCB(Milan).StructVersion = %d, want 0", milanTCB.StructVersion())
+	}
+	turinTCB, err := DecomposeProductTCB("Turin", raw)
+	if err != nil {
+		t.Fatalf("DecomposeProductTCB(Turin) failed: %v", err)
+	}
+	if turinTCB.StructVersion() != 1 {
+		t.Errorf("DecomposeProductTCB(Turin).StructVersion = %d, want 1", turinTCB.StructVersion())
+	}
+	if _, err := DecomposeProductTCB("Unknown", raw); err == nil {
+		t.Errorf("DecomposeProductTCB(Unknown) expected error, got nil")
+	}
+}

--- a/kds/kds_test.go
+++ b/kds/kds_test.go
@@ -37,10 +37,13 @@ func TestProductCertChainURL(t *testing.T) {
 }
 
 func TestVCEKCertURL(t *testing.T) {
-	hwid := make([]byte, abi.ChipIDSize)
+	hwid := make([]byte, VcekHWIDStruct0Size)
 	hwid[0] = 0xfe
-	hwid[abi.ChipIDSize-1] = 0xc0
-	got := VCEKCertURL("Milan", hwid, TCBVersionV0{})
+	hwid[VcekHWIDStruct0Size-1] = 0xc0
+	got, err := VCEKCertURL("Milan", hwid, TCBVersionV0{})
+	if err != nil {
+		t.Fatalf("VCEKCertURL(\"Milan\", %v, 0) unexpected error: %v", hwid, err)
+	}
 	want := "https://kdsintf.amd.com/vcek/v1/Milan/fe0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c0?blSPL=0&snpSPL=0&teeSPL=0&ucodeSPL=0"
 	if got != want {
 		t.Errorf("VCEKCertURL(\"Milan\", %v, 0) = %q, want %q", hwid, got, want)
@@ -139,13 +142,63 @@ func TestParseVCEKCertURL(t *testing.T) {
 	}{
 		{
 			name: "happy path",
-			url:  VCEKCertURL("Milan", hwid, TCBVersionV0{}),
+			url: func() string {
+				u, _ := VCEKCertURL("Milan", hwid, TCBVersionV0{})
+				return u
+			}(),
 			want: func() VCEKCert {
 				c := VCEKCertProduct("Milan")
 				c.HWID = hwid
 				c.TCB = TCBVersionV0{}
 				return c
 			}(),
+		},
+		{
+			name: "happy path turin",
+			url: func() string {
+				turinHwid := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+				tcb := TCBVersionV1{
+					FmcSpl:   1,
+					BlSpl:    2,
+					TeeSpl:   3,
+					SnpSpl:   4,
+					UcodeSpl: 5,
+				}
+				u, _ := VCEKCertURL("Turin", turinHwid, tcb)
+				return u
+			}(),
+			want: func() VCEKCert {
+				c := VCEKCertProduct("Turin")
+				c.HWID = []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+				c.TCB = TCBVersionV1{
+					FmcSpl:   1,
+					BlSpl:    2,
+					TeeSpl:   3,
+					SnpSpl:   4,
+					UcodeSpl: 5,
+				}
+				return c
+			}(),
+		},
+		{
+			name:    "fmcSPL rejected on Milan",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Milan/%s?fmcSPL=1&blSPL=2", hwidhex),
+			wantErr: "unexpected KDS TCB version URL argument \"fmcSPL\" for product line \"Milan\"",
+		},
+		{
+			name:    "fmcSPL rejected on Genoa",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Genoa/%s?fmcSPL=1", hwidhex),
+			wantErr: "unexpected KDS TCB version URL argument \"fmcSPL\" for product line \"Genoa\"",
+		},
+		{
+			name:    "Turin wrong HWID length 64 bytes",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?fmcSPL=1", hwidhex),
+			wantErr: "unexpected HWID length 64 for product \"Turin\", want 8",
+		},
+		{
+			name:    "Milan wrong HWID length 8 bytes",
+			url:     "https://kdsintf.amd.com/vcek/v1/Milan/0102030405060708?blSPL=1",
+			wantErr: "unexpected HWID length 8 for product \"Milan\", want 64",
 		},
 		{
 			name:    "bad query format",
@@ -305,6 +358,22 @@ func TestParseProductName(t *testing.T) {
 			input:   "ignored",
 			key:     abi.NoneReportSigner,
 			wantErr: "internal: unhandled reportSigner",
+		},
+		{
+			name:  "happy path Turin-B0",
+			input: "Turin-B0",
+			want: &pb.SevProduct{
+				Name:            pb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 0},
+			},
+		},
+		{
+			name:  "happy path Turin-B1",
+			input: "Turin-B1",
+			want: &pb.SevProduct{
+				Name:            pb.SevProduct_SEV_PRODUCT_TURIN,
+				MachineStepping: &wrapperspb.UInt32Value{Value: 1},
+			},
 		},
 	}
 	for _, tc := range tcs {
@@ -559,7 +628,6 @@ func TestStructVersionForProductLine(t *testing.T) {
 		})
 	}
 }
-
 func TestDecomposeProductTCB(t *testing.T) {
 	raw := uint64(0x0807060504030201)
 	milanTCB, err := DecomposeProductTCB("Milan", raw)
@@ -578,5 +646,192 @@ func TestDecomposeProductTCB(t *testing.T) {
 	}
 	if _, err := DecomposeProductTCB("Unknown", raw); err == nil {
 		t.Errorf("DecomposeProductTCB(Unknown) expected error, got nil")
+	}
+}
+
+func TestVCEKCertURLTurin(t *testing.T) {
+	hwid := make([]byte, VcekHWIDStruct1Size)
+	hwid[0] = 0xfe
+	hwid[VcekHWIDStruct1Size-1] = 0xc0
+	tcb := TCBVersionV1{
+		FmcSpl:   1,
+		BlSpl:    2,
+		TeeSpl:   3,
+		SnpSpl:   4,
+		UcodeSpl: 5,
+	}
+	got, err := VCEKCertURL("Turin", hwid, tcb)
+	if err != nil {
+		t.Fatalf("VCEKCertURL(\"Turin\", %v, %v) unexpected error: %v", hwid, tcb, err)
+	}
+	want := "https://kdsintf.amd.com/vcek/v1/Turin/fe000000000000c0?blSPL=2&fmcSPL=1&snpSPL=4&teeSPL=3&ucodeSPL=5"
+	if got != want {
+		t.Errorf("VCEKCertURL(\"Turin\", %v, %v) = %q, want %q", hwid, tcb, got, want)
+	}
+
+	hwid64 := make([]byte, abi.ChipIDSize)
+	copy(hwid64[:VcekHWIDStruct1Size], hwid)
+	got64, err := VCEKCertURL("Turin", hwid64, tcb)
+	if err != nil {
+		t.Fatalf("VCEKCertURL(\"Turin\", %v, %v) unexpected error: %v", hwid64, tcb, err)
+	}
+	if got64 != want {
+		t.Errorf("VCEKCertURL(\"Turin\", 64-byte hwid) = %q, want %q", got64, want)
+	}
+}
+
+func TestVCEKCertURLProductMismatch(t *testing.T) {
+	hwid64 := make([]byte, VcekHWIDStruct0Size)
+	hwid8 := make([]byte, VcekHWIDStruct1Size)
+
+	// V0 struct with Turin product should fail.
+	if _, err := VCEKCertURL("Turin", hwid8, TCBVersionV0{}); err == nil {
+		t.Errorf("VCEKCertURL(\"Turin\", hwid8, TCBVersionV0{}) expected error, got nil")
+	}
+
+	// V1 struct with Milan product should fail.
+	if _, err := VCEKCertURL("Milan", hwid64, TCBVersionV1{}); err == nil {
+		t.Errorf("VCEKCertURL(\"Milan\", hwid64, TCBVersionV1{}) expected error, got nil")
+	}
+
+	// V1 struct with Genoa product should fail.
+	if _, err := VCEKCertURL("Genoa", hwid64, TCBVersionV1{}); err == nil {
+		t.Errorf("VCEKCertURL(\"Genoa\", hwid64, TCBVersionV1{}) expected error, got nil")
+	}
+}
+
+func TestVCEKCertURLNilTCB(t *testing.T) {
+	if _, err := VCEKCertURL("Turin", make([]byte, VcekHWIDStruct1Size), nil); err == nil {
+		t.Errorf("VCEKCertURL with nil TCB expected error, got nil")
+	}
+}
+
+func TestVCEKCertURLUnknownProduct(t *testing.T) {
+	if _, err := VCEKCertURL("UnknownProduct", make([]byte, 8), TCBVersionV1{}); err == nil {
+		t.Errorf("VCEKCertURL with unknown product expected error, got nil")
+	}
+}
+
+func TestVCEKCertURLInvalidHWIDLength(t *testing.T) {
+	tcs := []struct {
+		name        string
+		productLine string
+		hwidLen     int
+		tcb         TCBVersion
+		wantErr     string
+	}{
+		{
+			name:        "milan with 8-byte hwid",
+			productLine: "Milan",
+			hwidLen:     8,
+			tcb:         TCBVersionV0{},
+			wantErr:     "hwid has size 8, want 64",
+		},
+		{
+			name:        "milan with empty hwid",
+			productLine: "Milan",
+			hwidLen:     0,
+			tcb:         TCBVersionV0{},
+			wantErr:     "hwid has size 0, want 64",
+		},
+		{
+			name:        "genoa with 8-byte hwid",
+			productLine: "Genoa",
+			hwidLen:     8,
+			tcb:         TCBVersionV0{},
+			wantErr:     "hwid has size 8, want 64",
+		},
+		{
+			name:        "turin with 0-byte hwid",
+			productLine: "Turin",
+			hwidLen:     0,
+			tcb:         TCBVersionV1{},
+			wantErr:     "hwid has size 0, want 8 or 64",
+		},
+		{
+			name:        "turin with 16-byte hwid",
+			productLine: "Turin",
+			hwidLen:     16,
+			tcb:         TCBVersionV1{},
+			wantErr:     "hwid has size 16, want 8 or 64",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := VCEKCertURL(tc.productLine, make([]byte, tc.hwidLen), tc.tcb)
+			if err == nil || !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("VCEKCertURL(%q, %d bytes) = %v, want error containing %q", tc.productLine, tc.hwidLen, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseVCEKCertURLTurin(t *testing.T) {
+	hwid := make([]byte, 8)
+	hwid[0] = 0xfe
+	hwid[7] = 0xc0
+	hwidhex := hex.EncodeToString(hwid)
+
+	tcs := []struct {
+		name    string
+		url     string
+		want    VCEKCert
+		wantErr string
+	}{
+		{
+			name: "happy path turin",
+			url:  fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?blSPL=2&fmcSPL=1&snpSPL=4&teeSPL=3&ucodeSPL=5", hwidhex),
+			want: VCEKCert{
+				Product:     "Turin",
+				ProductLine: "Turin",
+				HWID:        hwid,
+				TCB: TCBVersionV1{
+					FmcSpl:   1,
+					BlSpl:    2,
+					TeeSpl:   3,
+					SnpSpl:   4,
+					UcodeSpl: 5,
+				},
+			},
+		},
+		{
+			name:    "blSPL exceeds 127 on Turin",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?blSPL=128&fmcSPL=1&snpSPL=4&teeSPL=3&ucodeSPL=5", hwidhex),
+			wantErr: "invalid KDS TCB version URL argument value \"128\", want a value 0-127",
+		},
+		{
+			name:    "fmcSPL exceeds 127 on Turin",
+			url:     fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?blSPL=2&fmcSPL=128&snpSPL=4&teeSPL=3&ucodeSPL=5", hwidhex),
+			wantErr: "invalid KDS TCB version URL argument value \"128\", want a value 0-127",
+		},
+		{
+			name: "fmcSPL up to 127 allowed on Turin",
+			url:  fmt.Sprintf("https://kdsintf.amd.com/vcek/v1/Turin/%s?blSPL=2&fmcSPL=127&snpSPL=4&teeSPL=3&ucodeSPL=5", hwidhex),
+			want: VCEKCert{
+				Product:     "Turin",
+				ProductLine: "Turin",
+				HWID:        hwid,
+				TCB: TCBVersionV1{
+					FmcSpl:   127,
+					BlSpl:    2,
+					TeeSpl:   3,
+					SnpSpl:   4,
+					UcodeSpl: 5,
+				},
+			},
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseVCEKCertURL(tc.url)
+			if (err == nil && tc.wantErr != "") || (err != nil && !strings.Contains(err.Error(), tc.wantErr)) {
+				t.Fatalf("ParseVCEKCertURL(%q) = _, %v, want %q", tc.url, err, tc.wantErr)
+			}
+			if err == nil {
+				if diff := cmp.Diff(got, tc.want); diff != "" {
+					t.Errorf("ParseVCEKCertURL(%q) returned unexpected diff (-want +got):\n%s", tc.url, diff)
+				}
+			}
+		})
 	}
 }

--- a/testing/client/client.go
+++ b/testing/client/client.go
@@ -142,6 +142,16 @@ func GetSevQuoteProvider(tcs []test.TestCase, opts *test.DeviceOptions, tb testi
 					},
 				},
 			},
+			"Turin": {
+				{
+					ProductLine: "Turin",
+					ProductCerts: &trust.ProductCerts{
+						Ask:  sevQp.Device.Signer.Ask,
+						Ark:  sevQp.Device.Signer.Ark,
+						Asvk: sevQp.Device.Signer.Asvk,
+					},
+				},
+			},
 		}
 		badSnpRoot := map[string][]*trust.AMDRootCerts{
 			"Milan": {
@@ -160,6 +170,17 @@ func GetSevQuoteProvider(tcs []test.TestCase, opts *test.DeviceOptions, tb testi
 				{
 					Product:     "Genoa", // TODO(Issue#114): Remove
 					ProductLine: "Genoa",
+					ProductCerts: &trust.ProductCerts{
+						// No ASK, oops.
+						Ask:  sevQp.Device.Signer.Ark,
+						Ark:  sevQp.Device.Signer.Ark,
+						Asvk: sevQp.Device.Signer.Ark,
+					},
+				},
+			},
+			"Turin": {
+				{
+					ProductLine: "Turin",
 					ProductCerts: &trust.ProductCerts{
 						// No ASK, oops.
 						Ask:  sevQp.Device.Signer.Ark,

--- a/testing/fake_certs.go
+++ b/testing/fake_certs.go
@@ -431,6 +431,75 @@ func CustomExtensionsV0(tcb kds.TCBVersionV0, hwid []byte, cspid, productName st
 	return exts
 }
 
+// CustomExtensionsV1 returns an array of StructVersion 1 extensions following the KDS specification.
+func CustomExtensionsV1(tcb kds.TCBVersionV1, hwid []byte, cspid, productName string) []pkix.Extension {
+	asn1One, _ := asn1.Marshal(1)
+	var productNameAsn1 []byte
+	if hwid != nil {
+		productNameAsn1, _ = asn1.MarshalWithParams(productName, "ia5")
+	} else {
+		parts := strings.SplitN(productName, "-", 2)
+		productNameAsn1, _ = asn1.MarshalWithParams(parts[0], "ia5")
+	}
+	fmcSpl, _ := asn1.Marshal(int(tcb.FmcSpl))
+	blSpl, _ := asn1.Marshal(int(tcb.BlSpl))
+	teeSpl, _ := asn1.Marshal(int(tcb.TeeSpl))
+	snpSpl, _ := asn1.Marshal(int(tcb.SnpSpl))
+	spl5, _ := asn1.Marshal(int(tcb.Spl5))
+	spl6, _ := asn1.Marshal(int(tcb.Spl6))
+	spl7, _ := asn1.Marshal(int(tcb.Spl7))
+	ucodeSpl, _ := asn1.Marshal(int(tcb.UcodeSpl))
+	exts := []pkix.Extension{
+		{Id: kds.OidStructVersion, Value: asn1One},
+		{Id: kds.OidProductName1, Value: productNameAsn1},
+		{Id: kds.OidFmcSpl, Value: fmcSpl},
+		{Id: kds.OidBlSpl, Value: blSpl},
+		{Id: kds.OidTeeSpl, Value: teeSpl},
+		{Id: kds.OidSnpSpl, Value: snpSpl},
+		{Id: kds.OidSpl5, Value: spl5},
+		{Id: kds.OidSpl6, Value: spl6},
+		{Id: kds.OidSpl7, Value: spl7},
+		{Id: kds.OidUcodeSpl, Value: ucodeSpl},
+	}
+	if hwid != nil {
+		hwidBytes := hwid
+		if len(hwidBytes) > kds.VcekHWIDStruct1Size {
+			hwidBytes = hwidBytes[:kds.VcekHWIDStruct1Size]
+		}
+		asn1Hwid, _ := asn1.Marshal(hwidBytes)
+		exts = append(exts, pkix.Extension{Id: kds.OidHwid, Value: asn1Hwid})
+	} else {
+		if cspid == "" {
+			cspid = "placeholder"
+		}
+		asn1cspid, _ := asn1.MarshalWithParams(cspid, "ia5")
+		exts = append(exts, pkix.Extension{Id: kds.OidCspID, Value: asn1cspid})
+	}
+	return exts
+}
+
+func (b *AmdSignerBuilder) extensions(hwid []byte) []pkix.Extension {
+	tcb := b.TCB
+	if tcb == nil {
+		switch b.productLine() {
+		case "Turin":
+			tcb = kds.TCBVersionV1{}
+		case "Milan", "Genoa":
+			tcb = kds.TCBVersionV0{}
+		default:
+			return nil
+		}
+	}
+	switch v := tcb.(type) {
+	case kds.TCBVersionV1:
+		return CustomExtensionsV1(v, hwid, b.CSPID, b.productName())
+	case kds.TCBVersionV0:
+		return CustomExtensionsV0(v, hwid, b.CSPID, b.productName())
+	default:
+		return nil
+	}
+}
+
 func (b *AmdSignerBuilder) endorsementKeyPrecert(creationTime time.Time, hwid []byte, serialNumber *big.Int, key abi.ReportSigner) *x509.Certificate {
 	subject := amdPkixName(fmt.Sprintf("SEV-%s", key.String()), "0")
 	subject.SerialNumber = fmt.Sprintf("%x", serialNumber)
@@ -447,12 +516,12 @@ func (b *AmdSignerBuilder) endorsementKeyPrecert(creationTime time.Time, hwid []
 		SerialNumber:       serialNumber,
 		NotBefore:          time.Time{},
 		NotAfter:           creationTime.Add(vcekExpirationYears * 365 * 24 * time.Hour),
-		ExtraExtensions:    CustomExtensionsV0(kds.TCBVersionV0{}, hwid, b.CSPID, b.productName()),
+		ExtraExtensions:    b.extensions(hwid),
 	}
 }
 
 func (b *AmdSignerBuilder) certifyVcek() error {
-	cert := b.endorsementKeyPrecert(b.VcekCreationTime, make([]byte, abi.ChipIDSize), big.NewInt(0), abi.VcekReportSigner)
+	cert := b.endorsementKeyPrecert(b.VcekCreationTime, b.HWID[:], big.NewInt(0), abi.VcekReportSigner)
 	b.VcekCustom.override(cert)
 
 	caBytes, err := x509.CreateCertificate(insecureRandomness, cert, b.Ask, b.Keys.Vcek.Public(), b.Keys.Ask)

--- a/testing/fakekds.go
+++ b/testing/fakekds.go
@@ -116,20 +116,29 @@ func FakeKDSFromFile(path string) (*FakeKDS, error) {
 func FakeKDSFromSigner(signer *AmdSigner) (*FakeKDS, error) {
 	certs := &kpb.Certificates{}
 	rootBundles := map[string]*RootBundle{}
-	tcbVal := uint64(0)
+	productLine := kds.ProductLine(signer.Product)
+	var chipID []byte
+	switch productLine {
+	case "Milan", "Genoa":
+		chipID = signer.HWID[:]
+	case "Turin":
+		chipID = signer.HWID[:kds.VcekHWIDStruct1Size]
+	default:
+		return nil, fmt.Errorf("unknown product line: %q", productLine)
+	}
+	var tcbVal uint64
 	if signer.TCB != nil {
 		tcbVal = signer.TCB.Uint64()
 	}
 	certs.ChipCerts = []*kpb.Certificates_ChipTCBCerts{
 		{
-			ChipId: signer.HWID[:],
+			ChipId: chipID,
 			TcbCerts: map[uint64][]byte{
 				tcbVal: signer.Vcek.Raw,
 			},
 			Fms: abi.MaskedCpuid1EaxFromSevProduct(signer.Product),
 		},
 	}
-	productLine := kds.ProductLine(signer.Product)
 
 	b := &strings.Builder{}
 	if err := multierr.Combine(

--- a/testing/test_cases.go
+++ b/testing/test_cases.go
@@ -82,6 +82,15 @@ var userZeros14 = [64]byte{
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 0, 0,
 	0, 0, 0, 0, 0, 0, 1, 4}
+var userZeros15 = [64]byte{
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 0, 0,
+	0, 0, 0, 0, 0, 0, 1, 5}
 
 // zeroReport is a textproto representing an unsigned report response to UserZeros.
 // The policy just sets the debug bit and bit 17 to 1, and the signature algo 1 is the encoding for
@@ -250,10 +259,13 @@ func TestCases() []TestCase {
 	zeroRaw := TestRawReport(userZeros)
 	milanReportV3Raw := TestRawReportV3(userZeros13, 0x00a00f10)
 	genoaReportV3Raw := TestRawReportV3(userZeros14, 0x00a10f10)
+	turinReportV3Raw := TestRawReportV3(userZeros15, 0x00b00f20)
 	milanReportV3proto, _ := abi.ReportToProto(milanReportV3Raw[:])
 	genoaReportV3proto, _ := abi.ReportToProto(genoaReportV3Raw[:])
+	turinReportV3proto, _ := abi.ReportToProto(turinReportV3Raw[:])
 	milanReportV3, _ := prototext.MarshalOptions{Multiline: true}.Marshal(milanReportV3proto)
 	genoaReportV3, _ := prototext.MarshalOptions{Multiline: true}.Marshal(genoaReportV3proto)
+	turinReportV3, _ := prototext.MarshalOptions{Multiline: true}.Marshal(turinReportV3proto)
 	oneRaw := TestRawReport(userZeros1)
 	vlekRaw := CreateRawReport(&TestReportOptions{
 		ReportData: userZeros12[:],
@@ -296,6 +308,12 @@ func TestCases() []TestCase {
 			Input:       userZeros14,
 			Output:      genoaReportV3Raw,
 			OutputProto: string(genoaReportV3),
+		},
+		{
+			Name:        "zeros turin v3",
+			Input:       userZeros15,
+			Output:      turinReportV3Raw,
+			OutputProto: string(turinReportV3),
 		},
 	}
 }

--- a/validate/validate.go
+++ b/validate/validate.go
@@ -54,7 +54,7 @@ type Options struct {
 	ReportIDMA []byte
 	// Measurement is the expected MEASUREMENT field. Must be nil or 48 bytes long. Not checked if nil.
 	Measurement []byte
-	// ChipID is the expected CHIP_ID field. Must be nil or 64 bytes long. Not checked if nil.
+	// ChipID is the expected CHIP_ID field. Must be nil, abi.TurinSiliconIDSize bytes (Turin), or abi.ChipIDSize bytes. Not checked if nil.
 	ChipID []byte
 	// MinimumBuild is the minimum firmware build version reported in the attestation report.
 	MinimumBuild uint8
@@ -136,6 +136,10 @@ func lengthCheck(name string, length int, value []byte) error {
 }
 
 func checkOptionsLengths(opts *Options) error {
+	var chipIDErr error
+	if len(opts.ChipID) != 0 && len(opts.ChipID) != abi.TurinSiliconIDSize && len(opts.ChipID) != abi.ChipIDSize {
+		chipIDErr = fmt.Errorf("option %q length is %d. Want %d or %d", "chip_id", len(opts.ChipID), abi.TurinSiliconIDSize, abi.ChipIDSize)
+	}
 	return multierr.Combine(
 		lengthCheck("family_id", abi.FamilyIDSize, opts.FamilyID),
 		lengthCheck("image_id", abi.ImageIDSize, opts.ImageID),
@@ -144,7 +148,7 @@ func checkOptionsLengths(opts *Options) error {
 		lengthCheck("host_data", abi.HostDataSize, opts.HostData),
 		lengthCheck("report_id", abi.ReportIDSize, opts.ReportID),
 		lengthCheck("report_id_ma", abi.ReportIDMASize, opts.ReportIDMA),
-		lengthCheck("chip_id", abi.ChipIDSize, opts.ChipID))
+		chipIDErr)
 }
 
 // Converts "maj.min" to its uint16 representation or errors.
@@ -235,6 +239,25 @@ func PolicyToOptions(policy *cpb.Policy) (*Options, error) {
 	if err != nil {
 		return nil, err
 	}
+	var minTcb, minLaunchTcb kds.TCBVersion
+	switch policy.GetProduct().GetName() {
+	case spb.SevProduct_SEV_PRODUCT_TURIN:
+		if policy.GetMinimumTcb() != 0 {
+			minTcb = kds.DecomposeTCBVersionV1(policy.GetMinimumTcb())
+		}
+		if policy.GetMinimumLaunchTcb() != 0 {
+			minLaunchTcb = kds.DecomposeTCBVersionV1(policy.GetMinimumLaunchTcb())
+		}
+	case spb.SevProduct_SEV_PRODUCT_UNKNOWN, spb.SevProduct_SEV_PRODUCT_MILAN, spb.SevProduct_SEV_PRODUCT_GENOA:
+		if policy.GetMinimumTcb() != 0 {
+			minTcb = kds.DecomposeTCBVersionV0(policy.GetMinimumTcb())
+		}
+		if policy.GetMinimumLaunchTcb() != 0 {
+			minLaunchTcb = kds.DecomposeTCBVersionV0(policy.GetMinimumLaunchTcb())
+		}
+	default:
+		return nil, fmt.Errorf("unknown product: %v", policy.GetProduct().GetName())
+	}
 	opts := &Options{
 		MinimumGuestSvn:           policy.GetMinimumGuestSvn(),
 		GuestPolicy:               guestPolicy,
@@ -247,8 +270,8 @@ func PolicyToOptions(policy *cpb.Policy) (*Options, error) {
 		HostData:                  policy.GetHostData(),
 		ReportData:                policy.GetReportData(),
 		PlatformInfo:              platformInfo,
-		MinimumTCB:                kds.DecomposeTCBVersionV0(policy.GetMinimumTcb()),
-		MinimumLaunchTCB:          kds.DecomposeTCBVersionV0(policy.GetMinimumLaunchTcb()),
+		MinimumTCB:                minTcb,
+		MinimumLaunchTCB:          minLaunchTcb,
 		MinimumBuild:              uint8(policy.GetMinimumBuild()),
 		MinimumVersion:            minVersion,
 		RequireAuthorKey:          policy.GetRequireAuthorKey(),
@@ -332,7 +355,57 @@ func validateByteField(option, field string, size int, given, required []byte) e
 	return nil
 }
 
+// validateChipID verifies that the attestation report's CHIP_ID matches the expected ChipID option.
+//
+// AMD Publication #56860 Table 23 defines the attestation report's CHIP_ID as a fixed 64-byte
+// field (abi.ChipIDSize).
+//
+// For Family 19h (Milan, Genoa), the socket hardware ID is 64 bytes (AMD Publication #57230 Table 10).
+// For Family 1Ah (Turin and later), the socket hardware ID is 8 bytes (AMD Publication #57230 Table 11).
+// On Turin, the report buffer contains the 8-byte silicon ID in its prefix (abi.TurinSiliconIDSize).
+func validateChipID(product spb.SevProduct_SevProductName, reportChipID, expectedChipID []byte) error {
+	if len(expectedChipID) == 0 {
+		return nil
+	}
+	if len(expectedChipID) == abi.ChipIDSize {
+		if len(reportChipID) != abi.ChipIDSize {
+			return fmt.Errorf("report field CHIP_ID has size %d, want %d", len(reportChipID), abi.ChipIDSize)
+		}
+		if !bytes.Equal(expectedChipID, reportChipID) {
+			return fmt.Errorf("report field CHIP_ID is %s. Expect %s",
+				hex.EncodeToString(reportChipID), hex.EncodeToString(expectedChipID))
+		}
+		return nil
+	}
+	if len(expectedChipID) == abi.TurinSiliconIDSize {
+		switch product {
+		case spb.SevProduct_SEV_PRODUCT_TURIN:
+			if len(reportChipID) < abi.TurinSiliconIDSize {
+				return fmt.Errorf("report field CHIP_ID has size %d, want at least %d", len(reportChipID), abi.TurinSiliconIDSize)
+			}
+			if !bytes.Equal(expectedChipID, reportChipID[:abi.TurinSiliconIDSize]) {
+				return fmt.Errorf("report field CHIP_ID is %s. Expect %s",
+					hex.EncodeToString(reportChipID[:abi.TurinSiliconIDSize]), hex.EncodeToString(expectedChipID))
+			}
+			return nil
+		case spb.SevProduct_SEV_PRODUCT_UNKNOWN, spb.SevProduct_SEV_PRODUCT_MILAN, spb.SevProduct_SEV_PRODUCT_GENOA:
+			return fmt.Errorf("option ChipID must be nil or %d bytes", abi.ChipIDSize)
+		default:
+			return fmt.Errorf("unknown product: %v", product)
+		}
+	}
+	switch product {
+	case spb.SevProduct_SEV_PRODUCT_TURIN:
+		return fmt.Errorf("option ChipID for Turin must be nil, %d, or %d bytes", abi.TurinSiliconIDSize, abi.ChipIDSize)
+	case spb.SevProduct_SEV_PRODUCT_UNKNOWN, spb.SevProduct_SEV_PRODUCT_MILAN, spb.SevProduct_SEV_PRODUCT_GENOA:
+		return fmt.Errorf("option ChipID must be nil or %d bytes", abi.ChipIDSize)
+	default:
+		return fmt.Errorf("unknown product: %v", product)
+	}
+}
+
 func validateVerbatimFields(report *spb.Report, options *Options) error {
+	product := abi.SevProductFromCpuid1Eax(report.GetCpuid1EaxFms()).GetName()
 	return multierr.Combine(
 		validateByteField("ReportData", "REPORT_DATA", abi.ReportDataSize, report.GetReportData(), options.ReportData),
 		validateByteField("HostData", "HOST_DATA", abi.HostDataSize, report.GetHostData(), options.HostData),
@@ -341,7 +414,7 @@ func validateVerbatimFields(report *spb.Report, options *Options) error {
 		validateByteField("ReportID", "REPORT_ID", abi.ReportIDSize, report.GetReportId(), options.ReportID),
 		validateByteField("ReportIDMA", "REPORT_ID_MA", abi.ReportIDMASize, report.GetReportIdMa(), options.ReportIDMA),
 		validateByteField("Measurement", "MEASUREMENT", abi.MeasurementSize, report.GetMeasurement(), options.Measurement),
-		validateByteField("ChipID", "CHIP_ID", abi.ChipIDSize, report.GetChipId(), options.ChipID),
+		validateChipID(product, report.GetChipId(), options.ChipID),
 	)
 }
 
@@ -370,29 +443,44 @@ type reportTcbDescriptions struct {
 	cert partDescription
 }
 
-func getReportTcbs(report *spb.Report, certTcb kds.TCBVersion) *reportTcbDescriptions {
+func getReportTcbs(report *spb.Report, certTcb kds.TCBVersion, structVersion uint8) (*reportTcbDescriptions, error) {
+	var reported, current, committed, launch kds.TCBVersion
+	switch structVersion {
+	case 1:
+		reported = kds.DecomposeTCBVersionV1(report.GetReportedTcb())
+		current = kds.DecomposeTCBVersionV1(report.GetCurrentTcb())
+		committed = kds.DecomposeTCBVersionV1(report.GetCommittedTcb())
+		launch = kds.DecomposeTCBVersionV1(report.GetLaunchTcb())
+	case 0:
+		reported = kds.DecomposeTCBVersionV0(report.GetReportedTcb())
+		current = kds.DecomposeTCBVersionV0(report.GetCurrentTcb())
+		committed = kds.DecomposeTCBVersionV0(report.GetCommittedTcb())
+		launch = kds.DecomposeTCBVersionV0(report.GetLaunchTcb())
+	default:
+		return nil, fmt.Errorf("unsupported TCB structVersion: %d", structVersion)
+	}
 	return &reportTcbDescriptions{
 		reported: partDescription{
-			tcb:  kds.DecomposeTCBVersionV0(report.GetReportedTcb()),
+			tcb:  reported,
 			desc: "report's REPORTED_TCB",
 		},
 		current: partDescription{
-			tcb:  kds.DecomposeTCBVersionV0(report.GetCurrentTcb()),
+			tcb:  current,
 			desc: "report's CURRENT_TCB",
 		},
 		committed: partDescription{
-			tcb:  kds.DecomposeTCBVersionV0(report.GetCommittedTcb()),
+			tcb:  committed,
 			desc: "report's COMMITTED_TCB",
 		},
 		launch: partDescription{
-			tcb:  kds.DecomposeTCBVersionV0(report.GetLaunchTcb()),
+			tcb:  launch,
 			desc: "report's LAUNCH_TCB",
 		},
 		cert: partDescription{
 			tcb:  certTcb,
 			desc: "TCB of the V[CL]EK certificate",
 		},
-	}
+	}, nil
 }
 
 // policyTcbDescriptions is a collection of all TCB kinds that the validation policy specifies.
@@ -421,10 +509,14 @@ func tcbNeError(left, right partDescription) error {
 	if left.tcb == nil || right.tcb == nil {
 		return nil
 	}
-	if left.tcb.StructVersion() == right.tcb.StructVersion() && left.tcb.Uint64() == right.tcb.Uint64() {
-		return nil
+	if left.tcb.StructVersion() != right.tcb.StructVersion() {
+		return fmt.Errorf("the %s StructVersion %d does not match the %s StructVersion %d",
+			left.desc, left.tcb.StructVersion(), right.desc, right.tcb.StructVersion())
 	}
-	return fmt.Errorf("the %s 0x%x does not match the %s 0x%x", left.desc, left.tcb.Uint64(), right.desc, right.tcb.Uint64())
+	if left.tcb.Uint64() != right.tcb.Uint64() {
+		return fmt.Errorf("the %s 0x%x does not match the %s 0x%x", left.desc, left.tcb.Uint64(), right.desc, right.tcb.Uint64())
+	}
+	return nil
 }
 
 // tcbGtError returns an error if wantLower is greater than (in part) wantHigher. It enforces
@@ -432,6 +524,10 @@ func tcbNeError(left, right partDescription) error {
 func tcbGtError(wantLower, wantHigher partDescription) error {
 	if wantLower.tcb == nil || wantHigher.tcb == nil {
 		return nil
+	}
+	if wantLower.tcb.StructVersion() != wantHigher.tcb.StructVersion() {
+		return fmt.Errorf("the %s StructVersion %d does not match the %s StructVersion %d",
+			wantLower.desc, wantLower.tcb.StructVersion(), wantHigher.desc, wantHigher.tcb.StructVersion())
 	}
 	if wantLower.tcb.LE(wantHigher.tcb) {
 		return nil
@@ -443,8 +539,11 @@ func tcbGtError(wantLower, wantHigher partDescription) error {
 // validateTcb returns an error if the TCB values present in the report and V[CL]EK certificate do not
 // obey expected relationships with respect to the given validation policy, or with respect to
 // internal consistency checks.
-func validateTcb(report *spb.Report, certTcb kds.TCBVersion, options *Options) error {
-	reportTcbs := getReportTcbs(report, certTcb)
+func validateTcb(report *spb.Report, certTcb kds.TCBVersion, options *Options, structVersion uint8) error {
+	reportTcbs, err := getReportTcbs(report, certTcb, structVersion)
+	if err != nil {
+		return err
+	}
 	policyTcbs := getPolicyTcbs(options)
 
 	var provisionalErr error
@@ -748,10 +847,19 @@ func SnpAttestation(attestation *spb.Attestation, options *Options) error {
 			report.GetGuestSvn(), options.MinimumGuestSvn)
 	}
 
+	expectedStructVersion := uint8(0)
+	if abi.SevProductFromCpuid1Eax(report.GetCpuid1EaxFms()).GetName() == spb.SevProduct_SEV_PRODUCT_TURIN {
+		expectedStructVersion = 1
+	}
+	if info.SigningKey != abi.NoneReportSigner && exts.StructVersion != expectedStructVersion {
+		return fmt.Errorf("certificate structVersion %d does not match report expected structVersion %d",
+			exts.StructVersion, expectedStructVersion)
+	}
+
 	if err := multierr.Combine(
 		validatePolicy(report.GetPolicy(), options.GuestPolicy),
 		validateVerbatimFields(report, options),
-		validateTcb(report, exts.TCBVersion, options),
+		validateTcb(report, exts.TCBVersion, options, expectedStructVersion),
 		validateVersion(report, options),
 		validatePlatformInfo(report.GetPlatformInfo(), options.PlatformInfo),
 		validateKeys(report, options),
@@ -763,10 +871,22 @@ func SnpAttestation(attestation *spb.Attestation, options *Options) error {
 		return fmt.Errorf("report VMPL %d is not %d", report.GetVmpl(), *options.VMPL)
 	}
 
-	// MaskChipId might be 1 for the host, so only check if the the CHIP_ID is not all zeros.
-	if info.SigningKey == abi.VcekReportSigner && !allZero(report.GetChipId()) && !bytes.Equal(report.GetChipId(), exts.HWID[:]) {
-		return fmt.Errorf("report field CHIP_ID %s is not the same as the VCEK certificate's HWID %s",
-			hex.EncodeToString(report.GetChipId()), hex.EncodeToString(exts.HWID[:]))
+	// MaskChipId might be 1 for the host, so only check if the CHIP_ID is not all zeros.
+	// On Family 19h (Milan/Genoa), exts.HWID is 64 bytes (AMD #57230 Table 10) matching
+	// report.GetChipId() directly. On Family 1Ah (Turin), exts.HWID is 8 bytes (AMD #57230 Table 11)
+	// matching the 8-byte silicon ID prefix in report.GetChipId() (AMD #56860 Table 23).
+	if info.SigningKey == abi.VcekReportSigner {
+		hwidLen := len(exts.HWID)
+		if hwidLen == 0 {
+			return errors.New("certificate HWID is empty")
+		}
+		if len(report.GetChipId()) < hwidLen {
+			return fmt.Errorf("report field CHIP_ID has size %d, want at least %d", len(report.GetChipId()), hwidLen)
+		}
+		if !allZero(report.GetChipId()[:hwidLen]) && !bytes.Equal(report.GetChipId()[:hwidLen], exts.HWID) {
+			return fmt.Errorf("report field CHIP_ID %s is not the same as the VCEK certificate's HWID %s",
+				hex.EncodeToString(report.GetChipId()[:hwidLen]), hex.EncodeToString(exts.HWID))
+		}
 	}
 
 	return certTableOptions(attestation, options.CertTableOptions)

--- a/validate/validate_test.go
+++ b/validate/validate_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/google/go-sev-guest/verify"
 	"google.golang.org/protobuf/encoding/prototext"
 
+	cpb "github.com/google/go-sev-guest/proto/check"
 	spb "github.com/google/go-sev-guest/proto/sevsnp"
 )
 
@@ -614,5 +615,261 @@ func TestCheckMitigationVectors(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestValidateChipID(t *testing.T) {
+	hwid8 := []byte{1, 2, 3, 4, 5, 6, 7, 8}
+	reportChipID := make([]byte, abi.ChipIDSize)
+	copy(reportChipID, hwid8)
+
+	// Turin: 8-byte match
+	if err := validateChipID(spb.SevProduct_SEV_PRODUCT_TURIN, reportChipID, hwid8); err != nil {
+		t.Errorf("validateChipID with 8-byte HWID on Turin failed: %v", err)
+	}
+
+	// Turin: 64-byte match
+	if err := validateChipID(spb.SevProduct_SEV_PRODUCT_TURIN, reportChipID, reportChipID); err != nil {
+		t.Errorf("validateChipID with 64-byte HWID on Turin failed: %v", err)
+	}
+
+	// Turin: 8-byte mismatch
+	badHwid8 := []byte{1, 2, 3, 4, 5, 6, 7, 9}
+	if err := validateChipID(spb.SevProduct_SEV_PRODUCT_TURIN, reportChipID, badHwid8); err == nil {
+		t.Errorf("validateChipID with mismatched 8-byte HWID on Turin expected error, got nil")
+	}
+
+	// Turin: invalid option length (16 bytes)
+	if err := validateChipID(spb.SevProduct_SEV_PRODUCT_TURIN, reportChipID, make([]byte, 16)); err == nil {
+		t.Errorf("validateChipID with 16-byte HWID on Turin expected error, got nil")
+	}
+
+	// Turin: invalid option length (12 bytes)
+	if err := validateChipID(spb.SevProduct_SEV_PRODUCT_TURIN, reportChipID, make([]byte, 12)); err == nil {
+		t.Errorf("validateChipID with 12-byte HWID on Turin expected error, got nil")
+	}
+
+	// Milan: 8-byte option rejected
+	if err := validateChipID(spb.SevProduct_SEV_PRODUCT_MILAN, reportChipID, hwid8); err == nil {
+		t.Errorf("validateChipID with 8-byte HWID on Milan expected error, got nil")
+	}
+
+	// Milan: 64-byte match
+	if err := validateChipID(spb.SevProduct_SEV_PRODUCT_MILAN, reportChipID, reportChipID); err != nil {
+		t.Errorf("validateChipID with 64-byte HWID on Milan failed: %v", err)
+	}
+}
+
+func TestCheckOptionsLengthsChipID(t *testing.T) {
+	// Nil ChipID
+	if err := checkOptionsLengths(&Options{}); err != nil {
+		t.Errorf("checkOptionsLengths with nil ChipID failed: %v", err)
+	}
+	// Turin-size ChipID
+	if err := checkOptionsLengths(&Options{ChipID: make([]byte, abi.TurinSiliconIDSize)}); err != nil {
+		t.Errorf("checkOptionsLengths with %d-byte ChipID failed: %v", abi.TurinSiliconIDSize, err)
+	}
+	// 64-byte ChipID
+	if err := checkOptionsLengths(&Options{ChipID: make([]byte, abi.ChipIDSize)}); err != nil {
+		t.Errorf("checkOptionsLengths with %d-byte ChipID failed: %v", abi.ChipIDSize, err)
+	}
+	// 16-byte ChipID is invalid
+	if err := checkOptionsLengths(&Options{ChipID: make([]byte, 16)}); err == nil {
+		t.Errorf("checkOptionsLengths with 16-byte ChipID expected error, got nil")
+	}
+	// 12-byte ChipID is invalid
+	if err := checkOptionsLengths(&Options{ChipID: make([]byte, 12)}); err == nil {
+		t.Errorf("checkOptionsLengths with 12-byte ChipID expected error, got nil")
+	}
+}
+
+func TestTcbGtErrorStructVersionMismatch(t *testing.T) {
+	v0 := kds.TCBVersionV0{}
+	v1 := kds.TCBVersionV1{}
+	err := tcbGtError(
+		partDescription{tcb: v0, desc: "policy minimum TCB"},
+		partDescription{tcb: v1, desc: "report's REPORTED_TCB"},
+	)
+	if err == nil {
+		t.Fatalf("expected error on struct version mismatch, got nil")
+	}
+	wantSubstring := "StructVersion 0 does not match"
+	if !strings.Contains(err.Error(), wantSubstring) {
+		t.Errorf("tcbGtError returned %q, want substring %q", err.Error(), wantSubstring)
+	}
+}
+
+func TestTcbNeErrorStructVersionMismatch(t *testing.T) {
+	v0 := kds.TCBVersionV0{}
+	v1 := kds.TCBVersionV1{}
+	err := tcbNeError(
+		partDescription{tcb: v0, desc: "TCB of the V[CL]EK certificate"},
+		partDescription{tcb: v1, desc: "report's REPORTED_TCB"},
+	)
+	if err == nil {
+		t.Fatalf("expected error on struct version mismatch, got nil")
+	}
+	wantSubstring := "StructVersion 0 does not match"
+	if !strings.Contains(err.Error(), wantSubstring) {
+		t.Errorf("tcbNeError returned %q, want substring %q", err.Error(), wantSubstring)
+	}
+}
+
+func TestSnpAttestationCertificateStructVersionMismatch(t *testing.T) {
+	signMilan, err := test.DefaultTestOnlyCertChain("Milan-B0", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	signTurin, err := test.DefaultTestOnlyCertChain("Turin-B0", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	turinReport := &spb.Report{
+		SignerInfo:   abi.ComposeSignerInfo(abi.SignerInfo{SigningKey: abi.VcekReportSigner}),
+		Cpuid1EaxFms: abi.MaskedCpuid1EaxFromSevProduct(&spb.SevProduct{Name: spb.SevProduct_SEV_PRODUCT_TURIN}),
+	}
+	milanCertOnTurinReport := &spb.Attestation{
+		Report: turinReport,
+		CertificateChain: &spb.CertificateChain{
+			VcekCert: signMilan.Vcek.Raw,
+		},
+	}
+	err = SnpAttestation(milanCertOnTurinReport, &Options{})
+	if err == nil || !strings.Contains(err.Error(), "certificate structVersion 0 does not match report expected structVersion 1") {
+		t.Errorf("expected structVersion mismatch error, got: %v", err)
+	}
+
+	milanReport := &spb.Report{
+		SignerInfo:   abi.ComposeSignerInfo(abi.SignerInfo{SigningKey: abi.VcekReportSigner}),
+		Cpuid1EaxFms: abi.MaskedCpuid1EaxFromSevProduct(&spb.SevProduct{Name: spb.SevProduct_SEV_PRODUCT_MILAN}),
+	}
+	turinCertOnMilanReport := &spb.Attestation{
+		Report: milanReport,
+		CertificateChain: &spb.CertificateChain{
+			VcekCert: signTurin.Vcek.Raw,
+		},
+	}
+	err = SnpAttestation(turinCertOnMilanReport, &Options{})
+	if err == nil || !strings.Contains(err.Error(), "certificate structVersion 1 does not match report expected structVersion 0") {
+		t.Errorf("expected structVersion mismatch error, got: %v", err)
+	}
+}
+
+func TestSnpAttestationTurinSuccess(t *testing.T) {
+	signTurin, err := test.DefaultTestOnlyCertChain("Turin-B0", time.Now())
+	if err != nil {
+		t.Fatal(err)
+	}
+	exts, err := kds.VcekCertificateExtensions(signTurin.Vcek)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reportChipID := make([]byte, abi.ChipIDSize)
+	copy(reportChipID, exts.HWID)
+
+	turinReport := &spb.Report{
+		SignerInfo:   abi.ComposeSignerInfo(abi.SignerInfo{SigningKey: abi.VcekReportSigner}),
+		Cpuid1EaxFms: abi.MaskedCpuid1EaxFromSevProduct(&spb.SevProduct{Name: spb.SevProduct_SEV_PRODUCT_TURIN}),
+		Policy:       abi.SnpPolicyToBytes(abi.SnpPolicy{}),
+		ReportedTcb:  exts.TCBVersion.Uint64(),
+		CurrentTcb:   exts.TCBVersion.Uint64(),
+		CommittedTcb: exts.TCBVersion.Uint64(),
+		LaunchTcb:    exts.TCBVersion.Uint64(),
+		ChipId:       reportChipID,
+	}
+	attestation := &spb.Attestation{
+		Report: turinReport,
+		CertificateChain: &spb.CertificateChain{
+			VcekCert: signTurin.Vcek.Raw,
+		},
+	}
+
+	// Default options (no explicit constraints)
+	if err := SnpAttestation(attestation, &Options{}); err != nil {
+		t.Errorf("SnpAttestation with valid Turin report and cert failed: %v", err)
+	}
+
+	// Matching Turin ChipID option
+	if err := SnpAttestation(attestation, &Options{ChipID: exts.HWID}); err != nil {
+		t.Errorf("SnpAttestation with matching %d-byte ChipID failed: %v", abi.TurinSiliconIDSize, err)
+	}
+
+	// Mismatched Turin ChipID option
+	mismatchedTurin := make([]byte, abi.TurinSiliconIDSize)
+	copy(mismatchedTurin, exts.HWID)
+	mismatchedTurin[0] ^= 0xff
+	if err := SnpAttestation(attestation, &Options{ChipID: mismatchedTurin}); err == nil {
+		t.Errorf("SnpAttestation with mismatched %d-byte ChipID expected error, got nil", abi.TurinSiliconIDSize)
+	}
+
+	// Matching 64-byte ChipID option
+	if err := SnpAttestation(attestation, &Options{ChipID: reportChipID}); err != nil {
+		t.Errorf("SnpAttestation with matching 64-byte ChipID failed: %v", err)
+	}
+
+	// Mismatched 64-byte ChipID option
+	mismatched64 := make([]byte, abi.ChipIDSize)
+	copy(mismatched64, reportChipID)
+	mismatched64[0] ^= 0xff
+	if err := SnpAttestation(attestation, &Options{ChipID: mismatched64}); err == nil {
+		t.Errorf("SnpAttestation with mismatched 64-byte ChipID expected error, got nil")
+	}
+}
+
+func TestPolicyToOptions(t *testing.T) {
+	validPolicy := abi.SnpPolicyToBytes(abi.SnpPolicy{})
+
+	// Turin product with non-zero minimum_tcb decomposes to TCBVersionV1
+	turinPolicy := &cpb.Policy{
+		Policy:     validPolicy,
+		Product:    &spb.SevProduct{Name: spb.SevProduct_SEV_PRODUCT_TURIN},
+		MinimumTcb: 0x0102030405060708,
+	}
+	turinOpts, err := PolicyToOptions(turinPolicy)
+	if err != nil {
+		t.Fatalf("PolicyToOptions(turinPolicy) failed: %v", err)
+	}
+	if turinOpts.MinimumTCB == nil || turinOpts.MinimumTCB.StructVersion() != 1 {
+		t.Errorf("PolicyToOptions(turinPolicy).MinimumTCB StructVersion = %v, want 1",
+			turinOpts.MinimumTCB)
+	}
+
+	// Milan product with non-zero minimum_tcb decomposes to TCBVersionV0
+	milanPolicy := &cpb.Policy{
+		Policy:     validPolicy,
+		Product:    &spb.SevProduct{Name: spb.SevProduct_SEV_PRODUCT_MILAN},
+		MinimumTcb: 0x0102030405060708,
+	}
+	milanOpts, err := PolicyToOptions(milanPolicy)
+	if err != nil {
+		t.Fatalf("PolicyToOptions(milanPolicy) failed: %v", err)
+	}
+	if milanOpts.MinimumTCB == nil || milanOpts.MinimumTCB.StructVersion() != 0 {
+		t.Errorf("PolicyToOptions(milanPolicy).MinimumTCB StructVersion = %v, want 0",
+			milanOpts.MinimumTCB)
+	}
+
+	// Zero minimum_tcb leaves MinimumTCB as nil
+	zeroPolicy := &cpb.Policy{
+		Policy:     validPolicy,
+		Product:    &spb.SevProduct{Name: spb.SevProduct_SEV_PRODUCT_TURIN},
+		MinimumTcb: 0,
+	}
+	zeroOpts, err := PolicyToOptions(zeroPolicy)
+	if err != nil {
+		t.Fatalf("PolicyToOptions(zeroPolicy) failed: %v", err)
+	}
+	if zeroOpts.MinimumTCB != nil {
+		t.Errorf("PolicyToOptions(zeroPolicy).MinimumTCB = %v, want nil", zeroOpts.MinimumTCB)
+	}
+}
+
+func TestValidateTcbUnsupportedStructVersion(t *testing.T) {
+	report := &spb.Report{}
+	err := validateTcb(report, kds.TCBVersionV0{}, &Options{}, 2)
+	if err == nil || !strings.Contains(err.Error(), "unsupported TCB structVersion: 2") {
+		t.Errorf("validateTcb with structVersion 2 error = %v, want unsupported TCB structVersion: 2", err)
 	}
 }

--- a/verify/verify.go
+++ b/verify/verify.go
@@ -810,7 +810,18 @@ func fillInAttestation(ctx context.Context, attestation *spb.Attestation, option
 	switch info.SigningKey {
 	case abi.VcekReportSigner:
 		if len(chain.GetVcekCert()) == 0 {
-			vcekURL := kds.VCEKCertURL(productLine, report.GetChipId(), kds.DecomposeTCBVersionV0(report.GetReportedTcb()))
+			tcb, err := kds.DecomposeProductTCB(productLine, report.GetReportedTcb())
+			if err != nil {
+				return &trust.AttestationRecreationErr{
+					Msg: fmt.Sprintf("could not decompose reported TCB: %v", err),
+				}
+			}
+			vcekURL, err := kds.VCEKCertURL(productLine, report.GetChipId(), tcb)
+			if err != nil {
+				return &trust.AttestationRecreationErr{
+					Msg: fmt.Sprintf("could not construct VCEK certificate URL: %v", err),
+				}
+			}
 			vcek, err := trust.GetWith(ctx, getter, vcekURL)
 			if err != nil {
 				return &trust.AttestationRecreationErr{

--- a/verify/verify_test.go
+++ b/verify/verify_test.go
@@ -870,7 +870,9 @@ func TestV3KDSProduct(t *testing.T) {
 		"https://kdsintf.amd.com/vcek/v1/Milan/00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000?blSPL=0&snpSPL=0&teeSPL=0&ucodeSPL=0": []byte("milancert"),
 		"https://kdsintf.amd.com/vcek/v1/Milan/cert_chain": trust.AskArkMilanVcekBytes,
 		"https://kdsintf.amd.com/vcek/v1/Genoa/00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000?blSPL=0&snpSPL=0&teeSPL=0&ucodeSPL=0": []byte("genoacert"),
-		"https://kdsintf.amd.com/vcek/v1/Genoa/cert_chain": trust.AskArkGenoaVcekBytes,
+		"https://kdsintf.amd.com/vcek/v1/Genoa/cert_chain":                                                     trust.AskArkGenoaVcekBytes,
+		"https://kdsintf.amd.com/vcek/v1/Turin/0000000000000000?blSPL=0&fmcSPL=0&snpSPL=0&teeSPL=0&ucodeSPL=0": []byte("turincert"),
+		"https://kdsintf.amd.com/vcek/v1/Turin/cert_chain":                                                     trust.AskArkTurinVcekBytes,
 	})
 	options := &Options{
 		TrustedRoots: map[string][]*trust.AMDRootCerts{},
@@ -878,7 +880,7 @@ func TestV3KDSProduct(t *testing.T) {
 		Product:      abi.DefaultSevProduct(),
 		Getter:       getter,
 	}
-	for _, productLine := range []string{"Milan", "Genoa"} {
+	for _, productLine := range []string{"Milan", "Genoa", "Turin"} {
 		r := trust.AMDRootCertsProduct(productLine)
 		r.ProductCerts = &trust.ProductCerts{
 			Ark: signer.Ark,
@@ -886,7 +888,7 @@ func TestV3KDSProduct(t *testing.T) {
 		}
 		options.TrustedRoots[productLine] = []*trust.AMDRootCerts{r}
 	}
-	var gotGenoa, gotMilan bool
+	var gotGenoa, gotMilan, gotTurin bool
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
 			report, _ := abi.ReportToProto(tc.Output[:])
@@ -902,6 +904,11 @@ func TestV3KDSProduct(t *testing.T) {
 			case 0x00a10f10:
 				want = []byte("genoacert")
 				gotGenoa = true
+			case 0x00b00f20:
+				want = []byte("turincert")
+				gotTurin = true
+			default:
+				t.Fatalf("unexpected Cpuid1EaxFms: 0x%x", report.Cpuid1EaxFms)
 			}
 			got := a.CertificateChain.VcekCert
 			if !bytes.Equal(got, want) {
@@ -914,6 +921,9 @@ func TestV3KDSProduct(t *testing.T) {
 	}
 	if !gotGenoa {
 		t.Errorf("missed Genoa case")
+	}
+	if !gotTurin {
+		t.Errorf("missed Turin case")
 	}
 }
 


### PR DESCRIPTION
Depends on #196, #197, and #198.

Add support for validating Turin (Family 1Ah) SEV-SNP attestation reports and VCEK certificates:
- In `validate`, determine expected certificate `structVersion` from report CPUID FMS (1 for Turin, 0 for Milan/Genoa).
- Validate that the VCEK certificate `structVersion` matches the report CPUID.
- Validate the 8-byte Silicon ID prefix against the certificate HWID on Turin per AMD #56860 Table 23 and #57230 Table 11.
- In `validateChipID`, accept either 8-byte Silicon ID or 64-byte `CHIP_ID` options for Turin, and 64-byte `CHIP_ID` options for Milan/Genoa.
- In `verify`, decompose reported TCB and construct VCEK URLs for Turin reports.
- Add test coverage for Turin attestation validation and verification.